### PR TITLE
Make the BuildDir stored in tempest.yaml relative, update List to work with pagination

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -68,7 +68,7 @@ func connectRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("generate build dir: %w", err)
 	}
 
-	runners, cancel, err := runner.StartApps(context.TODO(), cfg)
+	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)
 	if err != nil {
 		return fmt.Errorf("start local app: %w", err)
 	}

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -59,7 +59,7 @@ func describeApp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("generate build dir: %w", err)
 	}
 
-	runners, cancel, err := runner.StartApps(context.TODO(), cfg)
+	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)
 	if err != nil {
 		return fmt.Errorf("start local app: %w", err)
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -80,7 +80,7 @@ func serveRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("generate build dir: %w", err)
 	}
 
-	runners, cancel, err := runner.StartApps(context.TODO(), cfg)
+	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)
 	if err != nil {
 		return fmt.Errorf("start local app: %w", err)
 	}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -56,7 +56,7 @@ func testRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cfg, _, err := config.ReadConfig()
+	cfg, cfgDir, err := config.ReadConfig()
 	if err != nil {
 		return fmt.Errorf("read config: %w", err)
 	}
@@ -66,7 +66,7 @@ func testRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("app %s:%s not found in config", testAppID, testAppVersion)
 	}
 
-	runners, cancel, err := runner.StartApps(context.TODO(), cfg)
+	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)
 	if err != nil {
 		return fmt.Errorf("start local app: %w", err)
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"connectrpc.com/connect"
@@ -25,17 +26,19 @@ type Runner struct {
 
 // Start the app runner and return clients for each service.
 // If path is provided, only that app client will be returned.
-func StartApps(ctx context.Context, cfg *config.TempestConfig) ([]Runner, func(), error) {
+func StartApps(ctx context.Context, cfg *config.TempestConfig, cfgDir string) ([]Runner, func(), error) {
+	absBuildDir := filepath.Join(cfgDir, cfg.BuildDir)
+
 	var cmd *exec.Cmd
-	info, err := os.Stat(cfg.BuildDir)
+	info, err := os.Stat(absBuildDir)
 	if err != nil {
 		return nil, nil, err
 	}
 	if info.IsDir() {
 		cmd = exec.Command("go", "run", ".")
-		cmd.Dir = cfg.BuildDir
+		cmd.Dir = absBuildDir
 	} else {
-		return nil, nil, fmt.Errorf("invalid build directory: %s", cfg.BuildDir)
+		return nil, nil, fmt.Errorf("invalid build directory: %s", absBuildDir)
 	}
 
 	// Start process

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Will be replaced at build time with LDFlags.
-var Version = "0.0.1"
+var Version = "v0.0.0-latest"


### PR DESCRIPTION
## Contents

1. BuildDir stored in the `tempest.yaml` should be a relative path, relative to the `cfgDir`.
2. Update the default version. This is used when installed via `go install github.com/tempestdx/cli@latest`
3. Updated `app test` List operation to implement the pagination rules that are used on the Tempest server.