### PR TITLE
Add --preserve-build-dir flag for testing, modify how single apps are run, update some error messages

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -4,11 +4,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var appCmd = &cobra.Command{
-	Use:   "app [command] [flags]",
-	Short: "Manage Tempest Apps",
-}
+var (
+	appPreserveBuildDir bool
+
+	appCmd = &cobra.Command{
+		Use:   "app [command] [flags]",
+		Short: "Manage Tempest Apps",
+	}
+)
 
 func init() {
 	rootCmd.AddCommand(appCmd)
+
+	appCmd.Flags().BoolVar(&appPreserveBuildDir, "preserve-build-dir", false, "Preserve the existing build directory. Useful for debugging")
 }

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -17,4 +17,7 @@ func init() {
 	rootCmd.AddCommand(appCmd)
 
 	appCmd.PersistentFlags().BoolVar(&appPreserveBuildDir, "preserve-build-dir", false, "Preserve the existing build directory. Useful for debugging")
+	if err := appCmd.PersistentFlags().MarkHidden("preserve-build-dir"); err != nil {
+		panic(err)
+	}
 }

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -16,5 +16,5 @@ var (
 func init() {
 	rootCmd.AddCommand(appCmd)
 
-	appCmd.Flags().BoolVar(&appPreserveBuildDir, "preserve-build-dir", false, "Preserve the existing build directory. Useful for debugging")
+	appCmd.PersistentFlags().BoolVar(&appPreserveBuildDir, "preserve-build-dir", false, "Preserve the existing build directory. Useful for debugging")
 }

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -70,19 +70,12 @@ func connectRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)
+	// Start the app runner
+	runner, cancel, err := runner.StartApp(context.Background(), cfg, cfgDir, id, version)
 	if err != nil {
-		return fmt.Errorf("start local app: %w", err)
+		return fmt.Errorf("start app: %w", err)
 	}
 	defer cancel()
-
-	var runner runner.Runner
-	for _, r := range runners {
-		if r.AppID == id && r.Version == version {
-			runner = r
-			break
-		}
-	}
 
 	cmd.Println(`Tempest App Connect
 -----------------------`)

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -63,9 +63,11 @@ func connectRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("app %s:%s not found", id, version)
 	}
 
-	err = generateBuildDir(cfg, cfgDir)
-	if err != nil {
-		return fmt.Errorf("generate build dir: %w", err)
+	if !appPreserveBuildDir {
+		err := generateBuildDir(cfg, cfgDir)
+		if err != nil {
+			return fmt.Errorf("generate build dir: %w", err)
+		}
 	}
 
 	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -64,7 +64,7 @@ func connectRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if !appPreserveBuildDir {
-		err := generateBuildDir(cfg, cfgDir)
+		err := generateBuildDir(cfg, cfgDir, id, version)
 		if err != nil {
 			return fmt.Errorf("generate build dir: %w", err)
 		}

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -61,19 +61,12 @@ func describeApp(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)
+	// Start the app runner
+	runner, cancel, err := runner.StartApp(context.Background(), cfg, cfgDir, id, version)
 	if err != nil {
-		return fmt.Errorf("start local app: %w", err)
+		return fmt.Errorf("start app: %w", err)
 	}
 	defer cancel()
-
-	var runner runner.Runner
-	for _, r := range runners {
-		if r.AppID == id && r.Version == version {
-			runner = r
-			break
-		}
-	}
 
 	res, err := runner.Client.Describe(context.TODO(), connect.NewRequest(&appv1.DescribeRequest{}))
 	if err != nil {

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -55,7 +55,7 @@ func describeApp(cmd *cobra.Command, args []string) error {
 	}
 
 	if !appPreserveBuildDir {
-		err := generateBuildDir(cfg, cfgDir)
+		err := generateBuildDir(cfg, cfgDir, id, version)
 		if err != nil {
 			return fmt.Errorf("generate build dir: %w", err)
 		}

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -54,9 +54,11 @@ func describeApp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("app %s:%s not found", id, version)
 	}
 
-	err = generateBuildDir(cfg, cfgDir)
-	if err != nil {
-		return fmt.Errorf("generate build dir: %w", err)
+	if !appPreserveBuildDir {
+		err := generateBuildDir(cfg, cfgDir)
+		if err != nil {
+			return fmt.Errorf("generate build dir: %w", err)
+		}
 	}
 
 	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -254,25 +254,25 @@ func generateBuildDir(cfg *config.TempestConfig, cfgPath string) error {
 	absBuildDir := filepath.Join(cfgPath, cfg.BuildDir)
 
 	if err := os.MkdirAll(absBuildDir, 0o755); err != nil {
-		return err
+		return fmt.Errorf("create build directory: %w", err)
 	}
 
 	// Symlink cfgPath/apps/ to the cfg.BuildDir/apps/ directory
 	err := os.Symlink(filepath.Join(cfgPath, "apps/"), filepath.Join(absBuildDir, "apps/"))
 	if err != nil {
 		if !os.IsExist(err) {
-			return err
+			return fmt.Errorf("symlink apps directory: %w", err)
 		}
 	}
 
 	f, err := fs.ReadFile(templatesFS, "templates/build/main.go_")
 	if err != nil {
-		return err
+		return fmt.Errorf("read main.go template: %w", err)
 	}
 
 	err = os.WriteFile(filepath.Join(absBuildDir, "main.go"), f, 0o644)
 	if err != nil {
-		return err
+		return fmt.Errorf("write main.go: %w", err)
 	}
 
 	// Remove go.mod if it exists
@@ -280,7 +280,7 @@ func generateBuildDir(cfg *config.TempestConfig, cfgPath string) error {
 	if _, err := os.Stat(goModPath); err == nil {
 		err := os.Remove(goModPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("remove existing go.mod: %w", err)
 		}
 	}
 
@@ -289,7 +289,7 @@ func generateBuildDir(cfg *config.TempestConfig, cfgPath string) error {
 	if _, err := os.Stat(goSumPath); err == nil {
 		err := os.Remove(goSumPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("remove existing go.sum: %w", err)
 		}
 	}
 
@@ -297,19 +297,19 @@ func generateBuildDir(cfg *config.TempestConfig, cfgPath string) error {
 	modInit.Dir = absBuildDir
 	err = modInit.Run()
 	if err != nil {
-		return err
+		return fmt.Errorf("go mod init: %w", err)
 	}
 
 	modTidy := exec.Command("go", "mod", "tidy")
 	modTidy.Dir = absBuildDir
 	err = modTidy.Run()
 	if err != nil {
-		return err
+		return fmt.Errorf("go mod tidy: %w", err)
 	}
 
 	err = os.WriteFile(filepath.Join(absBuildDir, "apps.go"), appsDotGoContent(cfg), 0o644)
 	if err != nil {
-		return err
+		return fmt.Errorf("write apps.go: %w", err)
 	}
 
 	return nil

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -75,9 +75,11 @@ func serveRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = generateBuildDir(cfg, cfgDir)
-	if err != nil {
-		return fmt.Errorf("generate build dir: %w", err)
+	if !appPreserveBuildDir {
+		err := generateBuildDir(cfg, cfgDir)
+		if err != nil {
+			return fmt.Errorf("generate build dir: %w", err)
+		}
 	}
 
 	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -76,7 +76,7 @@ func serveRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if !appPreserveBuildDir {
-		err := generateBuildDir(cfg, cfgDir)
+		err := generateBuildDir(cfg, cfgDir, id, version)
 		if err != nil {
 			return fmt.Errorf("generate build dir: %w", err)
 		}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -66,19 +66,11 @@ func testRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("app %s:%s not found in config", testAppID, testAppVersion)
 	}
 
-	runners, cancel, err := runner.StartApps(context.TODO(), cfg, cfgDir)
+	runner, cancel, err := runner.StartApp(context.Background(), cfg, cfgDir, testAppID, testAppVersion)
 	if err != nil {
-		return fmt.Errorf("start local app: %w", err)
+		return fmt.Errorf("start app: %w", err)
 	}
 	defer cancel()
-
-	var runner runner.Runner
-	for _, r := range runners {
-		if r.AppID == testAppID && r.Version == testAppVersion {
-			runner = r
-			break
-		}
-	}
 
 	des, err := runner.Client.Describe(context.TODO(), connect.NewRequest(&appv1.DescribeRequest{}))
 	if err != nil {


### PR DESCRIPTION
## Contents

1. Adds a new flag `--preserve-build-dir` to the `tempest app ...` command and all subcommands. Using this flag will prevent the CLI from regenerating the `.build` directory, which can sometimes be useful for debugging.
2. Updates error messages during build directory generation to be more helpful.
3. Adds a `runner.StartApp()` function which assists with running a single App. Modifications were made across the commands to make running a single app more reliable as well.
