### PR TITLE
Fix generating build directory, improve test output

### DIFF
--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -211,7 +211,7 @@ func getAppVersionDescriptor(appNameVersion string) (*appv1.DescribeResponse, er
 		}
 	}
 
-	runner, cancel, err := runner.StartApp(context.TODO(), cfg, cfgDir, id, version)
+	runner, cancel, err := runner.StartApp(context.TODO(), cfg, cfgDir, id, appVersion)
 	if err != nil {
 		return nil, fmt.Errorf("start local app: %w", err)
 	}

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -71,7 +71,7 @@ func connectRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Start the app runner
-	runner, cancel, err := runner.StartApp(context.Background(), cfg, cfgDir, id, version)
+	runner, cancel, err := runner.StartApp(context.Background(), cfg, cfgDir, id, appVersion)
 	if err != nil {
 		return fmt.Errorf("start app: %w", err)
 	}

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -62,7 +62,7 @@ func describeApp(cmd *cobra.Command, args []string) error {
 	}
 
 	// Start the app runner
-	runner, cancel, err := runner.StartApp(context.Background(), cfg, cfgDir, id, version)
+	runner, cancel, err := runner.StartApp(context.Background(), cfg, cfgDir, id, appVersion)
 	if err != nil {
 		return fmt.Errorf("start app: %w", err)
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -275,6 +275,11 @@ func generateBuildDir(cfg *config.TempestConfig, cfgPath, appID, version string)
 		return fmt.Errorf("write main.go: %w", err)
 	}
 
+	err = os.WriteFile(filepath.Join(absBuildDir, "apps.go"), appsDotGoContent(cfg, appID, version), 0o644)
+	if err != nil {
+		return fmt.Errorf("write apps.go: %w", err)
+	}
+
 	// Remove go.mod if it exists
 	goModPath := filepath.Join(absBuildDir, "go.mod")
 	if _, err := os.Stat(goModPath); err == nil {
@@ -305,11 +310,6 @@ func generateBuildDir(cfg *config.TempestConfig, cfgPath, appID, version string)
 	err = modTidy.Run()
 	if err != nil {
 		return fmt.Errorf("go mod tidy: %w", err)
-	}
-
-	err = os.WriteFile(filepath.Join(absBuildDir, "apps.go"), appsDotGoContent(cfg, appID, version), 0o644)
-	if err != nil {
-		return fmt.Errorf("write apps.go: %w", err)
 	}
 
 	return nil

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -256,7 +256,8 @@ func testRunE(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("marshal output: %w", err)
 			}
 
-			cmd.Println(pretty.Color(j, nil))
+			cmd.Println("External ID:", r.GetExternalId())
+			cmd.Printf("Properties:\n%s\n", pretty.Color(j, nil))
 		}
 	case "read":
 		if testExternalID == "" {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tempestdx/cli/internal/config"
 	"github.com/tempestdx/cli/internal/runner"
 	appv1 "github.com/tempestdx/protobuf/gen/go/tempestdx/app/v1"
+	"github.com/tidwall/pretty"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -146,13 +147,13 @@ func testRunE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("execute resource operation: %w", err)
 		}
 
-		cmd.Println("Resource created with ID: ", res.Msg.Resource.GetExternalId())
+		cmd.Println("\nResource created with ID:", res.Msg.Resource.GetExternalId())
 
 		j, err := json.MarshalIndent(res.Msg.Resource.Properties, "", "  ")
 		if err != nil {
 			return fmt.Errorf("marshal output: %w", err)
 		}
-		cmd.Printf("Properties: \n%s\n", string(j))
+		cmd.Printf("Properties:\n%s\n", pretty.Color(j, nil))
 
 	case "update":
 		if testExternalID == "" {
@@ -191,13 +192,13 @@ func testRunE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("execute resource operation: %w", err)
 		}
 
-		cmd.Println("Resource updated with ID: ", res.Msg.Resource.GetExternalId())
+		cmd.Println("\nResource updated with ID:", res.Msg.Resource.GetExternalId())
 
 		j, err := json.MarshalIndent(res.Msg.Resource.Properties, "", "  ")
 		if err != nil {
 			return fmt.Errorf("marshal output: %w", err)
 		}
-		cmd.Printf("Properties: \n%s\n", string(j))
+		cmd.Printf("Properties:\n%s\n", pretty.Color(j, nil))
 
 	case "delete":
 		if testExternalID == "" {
@@ -218,7 +219,7 @@ func testRunE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("execute resource operation: %w", err)
 		}
 
-		cmd.Println("Resource deleted with ID: ", res.Msg.Resource.GetExternalId())
+		cmd.Println("Resource deleted with ID:", res.Msg.Resource.GetExternalId())
 
 	case "list":
 		var next string
@@ -248,14 +249,14 @@ func testRunE(cmd *cobra.Command, args []string) error {
 			next = res.Msg.Next
 		}
 
-		cmd.Println("Resources: ")
+		cmd.Println("Resources:")
 		for _, r := range resources {
 			j, err := json.MarshalIndent(r.Properties, "", "  ")
 			if err != nil {
 				return fmt.Errorf("marshal output: %w", err)
 			}
 
-			cmd.Println(string(j))
+			cmd.Println(pretty.Color(j, nil))
 		}
 	case "read":
 		if testExternalID == "" {
@@ -283,7 +284,8 @@ func testRunE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("marshal resource properties: %w", err)
 		}
 
-		cmd.Printf("Resource: \n%s\n", string(j))
+		cmd.Println("\nResource:", res.Msg.Resource.GetExternalId())
+		cmd.Printf("Properties:\n%s\n", pretty.Color(j, nil))
 	}
 
 	return nil

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -256,7 +256,7 @@ func testRunE(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("marshal output: %w", err)
 			}
 
-			cmd.Println("External ID:", r.GetExternalId())
+			cmd.Println("\nExternal ID:", r.GetExternalId())
 			cmd.Printf("Properties:\n%s\n", pretty.Color(j, nil))
 		}
 	case "read":

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/tempestdx/openapi v0.1.2
 	github.com/tempestdx/protobuf v0.1.1
 	github.com/tempestdx/sdk-go v0.1.2
+	github.com/tidwall/pretty v1.2.1
 	github.com/zalando/go-keyring v0.2.6
 	google.golang.org/protobuf v1.35.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/tempestdx/protobuf v0.1.1 h1:lXr/c66pounQn7pIbN+A2eA+3z9tN7nmVjbRurNA
 github.com/tempestdx/protobuf v0.1.1/go.mod h1:9CmOJ2y+f9Hjo6XwXscDMb+RuYn8MnPXRtPSkt/yG1g=
 github.com/tempestdx/sdk-go v0.1.2 h1:2Q+enKqcmM90z2rbuIVj/mslE5NXYeDALbw58vFE0vk=
 github.com/tempestdx/sdk-go v0.1.2/go.mod h1:mQevP30peia1x4arxKwP8FIxVr18UgaesbPLmKzuybU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
 github.com/yuin/goldmark v1.7.4 h1:BDXOHExt+A7gwPCJgPIIq7ENvceR7we7rOS9TNoLZeg=
 github.com/yuin/goldmark v1.7.4/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -97,7 +97,7 @@ func StartApps(ctx context.Context, cfg *config.TempestConfig, cfgDir string) ([
 }
 
 // StartApp starts a single app runner and returns a client for the service.
-func StartApp(ctx context.Context, cfg *config.TempestConfig, cfgDir, appID, version string) (Runner, func(), error) {
+func StartApp(ctx context.Context, cfg *config.TempestConfig, cfgDir, appID string, appVersion *config.AppVersion) (Runner, func(), error) {
 	absBuildDir := filepath.Join(cfgDir, cfg.BuildDir)
 
 	var cmd *exec.Cmd
@@ -146,9 +146,7 @@ func StartApp(ctx context.Context, cfg *config.TempestConfig, cfgDir, appID, ver
 		}
 	}()
 
-	av := cfg.LookupAppByVersion(appID, version)
-
-	runner, err := createRunner(ctx, appID, av, port)
+	runner, err := createRunner(ctx, appID, appVersion, port)
 	if err != nil {
 		return Runner{}, nil, err
 	}


### PR DESCRIPTION
## Content

1. Moves `apps.go` generation before `go mod tidy` so dependencies are properly downloaded.
2. Improve output of `tempest app test` to use colors for the properties output, and more consistency across operations.
3. FIX: Generate build directory when using `tempest app test`.

## Screenshots

![2024-11-06 at 09 21 05](https://github.com/user-attachments/assets/c8bdf8ed-f142-40b6-9dea-34dcb5cecc1e)
