### PR TITLE
Support TEMPEST_TOKEN_FILE env

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -53,18 +53,13 @@ func init() {
 }
 
 func authShowRunE(cmd *cobra.Command, args []string) error {
-	tokenEnv := os.Getenv("TEMPEST_TOKEN")
-
 	token, err := tokenStore.Get()
 	if err != nil && !errors.Is(err, keyring.ErrNotFound) {
 		return err
 	}
 
-	if token == "" {
-		return errors.New("No token found. Please login with 'tempest auth login' or set the TEMPEST_TOKEN environment variable")
-	}
-
-	cmd.Println(fmt.Sprintf(`TEMPEST_TOKEN="%s"`, tokenEnv))
+	cmd.Println(fmt.Sprintf(`TEMPEST_TOKEN="%s"`, os.Getenv("TEMPEST_TOKEN")))
+	cmd.Println(fmt.Sprintf(`TEMPEST_TOKEN_FILE="%s"`, os.Getenv("TEMPEST_TOKEN_FILE")))
 	cmd.Println(fmt.Sprintf("Token from keychain: %s", token))
 
 	return nil

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -18,7 +17,6 @@ import (
 	appapi "github.com/tempestdx/openapi/app"
 	appv1 "github.com/tempestdx/protobuf/gen/go/tempestdx/app/v1"
 	appsdk "github.com/tempestdx/sdk-go/app"
-	"github.com/zalando/go-keyring"
 )
 
 var connectCmd = &cobra.Command{
@@ -41,17 +39,7 @@ func connectRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	token := os.Getenv("TEMPEST_TOKEN")
-	if token == "" {
-		var err error
-		token, err = tokenStore.Get()
-		if err != nil {
-			if errors.Is(err, keyring.ErrNotFound) {
-				return fmt.Errorf("token not found. Please login with 'tempest auth login' or set the TEMPEST_TOKEN environment variable")
-			}
-			return fmt.Errorf("get token: %w", err)
-		}
-	}
+	token := loadTempestToken(cmd)
 
 	cfg, cfgDir, err := config.ReadConfig()
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,3 +54,28 @@ func init() {
 
 	tokenStore = &secret.Keyring{}
 }
+
+// loadTempestToken loads the Tempest token from the environment or the keyring.
+// Load order: TEMPEST_TOKEN_FILE, TEMPEST_TOKEN, keyring.
+func loadTempestToken(cmd *cobra.Command) string {
+	if t := os.Getenv("TEMPEST_TOKEN_FILE"); t != "" {
+		b, err := os.ReadFile(t)
+		if err != nil {
+			cmd.PrintErrf("read token file: %v\n", err)
+			os.Exit(1)
+		}
+		return string(b)
+	}
+
+	if t := os.Getenv("TEMPEST_TOKEN"); t != "" {
+		return t
+	}
+
+	t, err := tokenStore.Get()
+	if err != nil {
+		cmd.PrintErrf("get token: %v\n", err)
+		os.Exit(1)
+	}
+
+	return t
+}


### PR DESCRIPTION
## Contents

- Adds support for `TEMPEST_TOKEN_FILE` environment variable. This environment variable will be checked before `TEMPEST_TOKEN` and should point to a file that contains the token.
- Removes invalid error condition from `tempest auth show`.