### PR TITLE
Usability improvments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Pull requests from the community are welcome. If you submit one, please keep the
 following guidelines in mind:
 
 1. Code must be `go fmt` compliant.
-2. All types, structs and funcs should be documented.
+2. All types, structs and functions should be documented.
 3. Ensure that `go test` succeeds.
 
 ## Test

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -175,12 +175,12 @@ func waitforYesNo() bool {
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		fmt.Print("(y/n): ")
+		fmt.Print("(Y/n): ")
 		input, _ := reader.ReadString('\n')
 		input = strings.TrimSpace(input)
 
 		switch input {
-		case "y", "Y":
+		case "y", "Y", "":
 			return true
 		case "n", "N":
 			return false

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ var (
 	apiEndpoint string
 	cfgFile     string
 	tokenStore  secret.TokenStore
+	debugMode   bool
 
 	rootCmd = &cobra.Command{
 		Use:     "tempest [command] [flags]",
@@ -51,6 +52,7 @@ func init() {
 	rootCmd.AddCommand(docCmd)
 	rootCmd.PersistentFlags().StringVar(&apiEndpoint, "api-endpoint", TempestProdAPI, "The Tempest API endpoint to connect to.")
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "full path to the config file (default is $WORKDIR/tempest.yaml)")
+	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Enable verbose logging")
 
 	tokenStore = &secret.Keyring{}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -285,8 +285,8 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 					continue
 				}
 
-				// post the response to the Tempest API api
-				logger.Info("posting response to Tempest API api")
+				// post the response to the Tempest API
+				logger.Info("posting response to Tempest API")
 				_, err = tempestClient.PostAppsOperationsReport(context.TODO(), appapi.PostAppsOperationsReportJSONRequestBody{
 					TaskId:   nextTask.JSON200.TaskId,
 					Response: response,
@@ -366,8 +366,8 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 					continue
 				}
 
-				// post the response to the Tempest API api
-				logger.Info("posting response to Tempest API api")
+				// post the response to the Tempest API
+				logger.Info("posting response to Tempest API")
 				_, err = tempestClient.PostAppsOperationsReport(context.TODO(), appapi.PostAppsOperationsReportJSONRequestBody{
 					TaskId:   nextTask.JSON200.TaskId,
 					Response: response,

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -169,7 +169,7 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 
 				input, err := structpb.NewStruct(*v.Input)
 				if err != nil {
-					logger.Error("prepare operation reuest fail", "error", err)
+					logger.Error("prepare operation request fail", "error", err)
 					time.Sleep(pollingInterval)
 					continue
 				}

--- a/cmd/templates/helloworld/app.go_
+++ b/cmd/templates/helloworld/app.go_
@@ -2,36 +2,65 @@ package {{ .PackageName }}
 
 import (
 	"context"
+	_ "embed"
 	"strconv"
 	"time"
 
+	// Our SDK that defines interface between your app and Tempest.
 	"github.com/tempestdx/sdk-go/app"
 )
 
+// Embedding the schema files into the binary isn't necessary
+// but it makes it easier to distribute the app as a single binary
+// and keeps the codebase clean.
+var (
+	//go:embed properties_schema.json
+	propertiesSchema []byte
+	//go:embed create_schema.json
+	createSchema []byte
+)
+
+// Tempest Apps operate on Resources. Good example of a resource would be
+// VM instance or cloud storage bucket. But in reality what it represents
+// is limited only by your imagination.
 var resourceDefinition = app.ResourceDefinition{
 	Type:             "example",
 	DisplayName:      "Example Resource",
 	LifecycleStage:   app.LifecycleStageCode,
-	PropertiesSchema: app.MustParseJSONSchema(app.GenericEmptySchema),
+	PropertiesSchema: app.MustParseJSONSchema(propertiesSchema),
 }
 
+// createFn is a function that will be called when user requests to create a new resource.
 func createFn(_ context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
 	return &app.OperationResponse{
 		Resource: &app.Resource{
+			// ExternalID is a unique identifier for the resource. It is used to identify
+			// the resource in the system. It is recommended to use a globally unique identifier
+			// for this field.
 			ExternalID:  strconv.Itoa(int(time.Now().Unix())),
 			DisplayName: "Example Resource",
-			Type:        req.Resource.Type,
-			Properties:  map[string]any{},
+			// Properties is a map of key-value pairs that describe the resource.
+			// It will be used to display the resource in the UI.
+			Properties: map[string]any{
+				"name": req.Input["name"],
+			},
 		},
 	}, nil
 }
 
+// App returns a new instance of the Tempest App.
+// Used internally by the Tempest CLI to serve the app.
 func App() *app.App {
+	// Register the create operation with the resource definition.
 	resourceDefinition.CreateFn(
+		// our create function
 		createFn,
-		app.MustParseJSONSchema(app.GenericEmptySchema),
+		// schema for the create operation
+		app.MustParseJSONSchema(createSchema),
 	)
 
+	// Return a new instance of the Tempest App with the defined resource.
+	// One app can have multiple resources.
 	return app.New(
 		app.WithResourceDefinition(resourceDefinition),
 	)

--- a/cmd/templates/helloworld/app.go_
+++ b/cmd/templates/helloworld/app.go_
@@ -10,9 +10,6 @@ import (
 	"github.com/tempestdx/sdk-go/app"
 )
 
-// Embedding the schema files into the binary isn't necessary
-// but it makes it easier to distribute the app as a single binary
-// and keeps the codebase clean.
 var (
 	//go:embed properties_schema.json
 	propertiesSchema []byte

--- a/cmd/templates/helloworld/app.go_
+++ b/cmd/templates/helloworld/app.go_
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	// Our SDK that defines interface between your app and Tempest.
+	// Tempest SDK defines interface between the app and Tempest API.
 	"github.com/tempestdx/sdk-go/app"
 )
 

--- a/cmd/templates/helloworld/app.go_
+++ b/cmd/templates/helloworld/app.go_
@@ -30,7 +30,7 @@ var resourceDefinition = app.ResourceDefinition{
 	PropertiesSchema: app.MustParseJSONSchema(propertiesSchema),
 }
 
-// createFn is a function that will be called when user requests to create a new resource.
+// createFn is a function that will be invoked when the user requests the creation of a new resource.
 func createFn(_ context.Context, req *app.OperationRequest) (*app.OperationResponse, error) {
 	return &app.OperationResponse{
 		Resource: &app.Resource{

--- a/cmd/templates/helloworld/app.go_
+++ b/cmd/templates/helloworld/app.go_
@@ -35,7 +35,7 @@ func createFn(_ context.Context, req *app.OperationRequest) (*app.OperationRespo
 	return &app.OperationResponse{
 		Resource: &app.Resource{
 			// ExternalID is a unique identifier for the resource. It is used to identify
-			// the resource in the system. It is recommended to use a globally unique identifier
+			// the resource in Tempest. It is recommended to use a globally unique identifier
 			// for this field.
 			ExternalID:  strconv.Itoa(int(time.Now().Unix())),
 			DisplayName: "Example Resource",

--- a/cmd/templates/helloworld/app.go_
+++ b/cmd/templates/helloworld/app.go_
@@ -32,7 +32,7 @@ func createFn(_ context.Context, req *app.OperationRequest) (*app.OperationRespo
 	return &app.OperationResponse{
 		Resource: &app.Resource{
 			// ExternalID is a unique identifier for the resource. It is used to identify
-			// the resource in Tempest. It is recommended to use a globally unique identifier
+			// the resource in Tempest. It is required to use a globally unique identifier
 			// for this field.
 			ExternalID:  strconv.Itoa(int(time.Now().Unix())),
 			DisplayName: "Example Resource",

--- a/cmd/templates/helloworld/app.go_
+++ b/cmd/templates/helloworld/app.go_
@@ -39,8 +39,8 @@ func createFn(_ context.Context, req *app.OperationRequest) (*app.OperationRespo
 			// for this field.
 			ExternalID:  strconv.Itoa(int(time.Now().Unix())),
 			DisplayName: "Example Resource",
-			// Properties is a map of key-value pairs that describe the resource.
-			// It will be used to display the resource in the UI.
+			// Properties allow you to define the resource specific metadata
+			// that you want displayed and tracked in your software catalog.
 			Properties: map[string]any{
 				"name": req.Input["name"],
 			},

--- a/cmd/templates/helloworld/create_schema.json
+++ b/cmd/templates/helloworld/create_schema.json
@@ -9,7 +9,7 @@
             "description": "The name of the repository.",
             "pattern": "^[A-Za-z0-9_.-]+$",
             "examples": [
-                "furbulator"
+                "my-repository"
             ]
         }
     },

--- a/cmd/templates/helloworld/create_schema.json
+++ b/cmd/templates/helloworld/create_schema.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.tempestdx.io/privateapps/myapp/create.json",
+    "type": "object",
+    "properties": {
+        "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "The name of the repository.",
+            "pattern": "^[A-Za-z0-9_.-]+$",
+            "examples": [
+                "furbulator"
+            ]
+        }
+    },
+    "required": [
+        "name"
+    ],
+    "additionalProperties": false
+}

--- a/cmd/templates/helloworld/create_schema.json
+++ b/cmd/templates/helloworld/create_schema.json
@@ -6,10 +6,10 @@
         "name": {
             "title": "Name",
             "type": "string",
-            "description": "The name of the repository.",
+            "description": "The name of the resource.",
             "pattern": "^[A-Za-z0-9_.-]+$",
             "examples": [
-                "my-repository"
+                "my-resource"
             ]
         }
     },

--- a/cmd/templates/helloworld/properties_schema.json
+++ b/cmd/templates/helloworld/properties_schema.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.tempestdx.io/privateapps/myapp/properties.json",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The short name of the resource"
+        }
+    },
+    "required": [
+        "name"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
1. `tempest app serve` uses structured log output now
2. Logs are much less verbose by default. Use `--debug` to get old behavior.
3. Basic app generated with `tempest app init` contains more comments, example of input field and resource properties
4. All questions that ends with `(Y/n)` like for example `Initialize a new configuration here? (Y/n)` default to Yes when empty input is provided