### PR TITLE
TEM-2485: Add Healthcheck to scaffolded app

### DIFF
--- a/cmd/templates/helloworld/app.go_
+++ b/cmd/templates/helloworld/app.go_
@@ -22,7 +22,7 @@ var (
 // is limited only by your imagination.
 var resourceDefinition = app.ResourceDefinition{
 	Type:             "example",
-	DisplayName:      "Example Resource",
+	DisplayName:      "My Resource",
 	LifecycleStage:   app.LifecycleStageCode,
 	PropertiesSchema: app.MustParseJSONSchema(propertiesSchema),
 }
@@ -35,7 +35,7 @@ func createFn(_ context.Context, req *app.OperationRequest) (*app.OperationRespo
 			// the resource in Tempest. It is required to use a globally unique identifier
 			// for this field.
 			ExternalID:  strconv.Itoa(int(time.Now().Unix())),
-			DisplayName: "Example Resource",
+			DisplayName: "Example resource name",
 			// Properties allow you to define the resource specific metadata
 			// that you want displayed and tracked in your software catalog.
 			Properties: map[string]any{

--- a/cmd/templates/helloworld/app.go_
+++ b/cmd/templates/helloworld/app.go_
@@ -56,6 +56,14 @@ func App() *app.App {
 		app.MustParseJSONSchema(createSchema),
 	)
 
+	resourceDefinition.HealthCheckFn(func(_ context.Context) (*app.HealthCheckResponse, error) {
+		// This is a simple health check that always returns healthy
+		// You can implement your own health check logic here
+		return &app.HealthCheckResponse{
+			Status: app.HealthCheckStatusHealthy,
+		}, nil
+	})
+
 	// Return a new instance of the Tempest App with the defined resource.
 	// One app can have multiple resources.
 	return app.New(


### PR DESCRIPTION
This PR adds healthcheck to scaffolded app.

QA:
Build dev CLI client - `go build -o /Users/lcf/go/bin/tempest-dev ./tempest`

```
➜  tempest-dev app init hello-world
There was no Tempest configuration found in this directory or above it.
Initialize a new configuration here? (Y/n):
Tempest App Initialization
--------------------------

Initializing app: hello-world:v1
Location: /Users/lcf/tem-2485/apps/hello-world/v1


✅ App hello-world:v1 initialized successfully!

Next steps:

1. To see the capabilities of your app, run:
   tempest app describe hello-world:v1

➜  tempest-dev app describe hello-world:v1
Tempest App Description
-----------------------

Describing app: hello-world:v1
Location: /Users/lcf/tem-2485/apps/hello-world/v1

Resource Type: Example Resource

Operations Supported:
- ❌ Read
- ❌ List
- ✅ Create
- ❌ Update
- ❌ Delete

Health Check Supported: ✅
```