### PR TITLE
TEM-1974: Respect pollingInterval in case of errors / hide api key during input

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -389,8 +389,12 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 		case http.StatusInternalServerError:
 			logger.Error("internal server error, sleeping")
 			time.Sleep(pollingInterval)
+		case http.StatusUnauthorized:
+			logger.Error("unauthorized, expired/revoked token")
+			time.Sleep(pollingInterval)
 		default:
 			logger.Error("unexpected status", "status", nextTask.Status(), "status_code", nextTask.StatusCode())
+			time.Sleep(pollingInterval)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/tempestdx/sdk-go v0.1.5
 	github.com/tidwall/pretty v1.2.1
 	github.com/zalando/go-keyring v0.2.6
+	golang.org/x/term v0.28.0
 	google.golang.org/protobuf v1.36.5
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -56,7 +57,6 @@ require (
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect


### PR DESCRIPTION
## Ticket number
TEM-1974

## Contents
1. Respect pollingInterval in case of errors
2. Hide API key input for `tempest auth login`