### PR TITLE
Add LIST and GET commands for basic objects

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/tempestdx/cli/internal/secret"
+	appapi "github.com/tempestdx/openapi/app"
+)
+
+var projectCmd = &cobra.Command{
+	Use:   "project",
+	Short: "Manage projects",
+	Long:  `List and get projects from your Tempest App`,
+}
+
+var projectListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all projects",
+	Args:  cobra.NoArgs,
+	RunE:  listProjects,
+}
+
+var projectGetCmd = &cobra.Command{
+	Use:   "get <project_id>",
+	Short: "Get a specific project",
+	Args:  cobra.ExactArgs(1),
+	RunE:  getProject,
+}
+
+func init() {
+	rootCmd.AddCommand(projectCmd)
+	projectCmd.AddCommand(projectListCmd)
+	projectCmd.AddCommand(projectGetCmd)
+}
+
+func listProjects(cmd *cobra.Command, args []string) error {
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	res, err := tempestClient.ProjectCollectionWithResponse(context.TODO(), appapi.ProjectCollectionJSONRequestBody{
+		After: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("list projects: %w", err)
+	}
+
+	if res.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", res.Status())
+	}
+
+	cmd.Println("Projects:")
+	for _, edge := range res.JSON200.Edges {
+		project := edge.Node
+		cmd.Printf("- ID: %s\n", project.Id)
+		cmd.Printf("  Name: %s\n", project.Name)
+		cmd.Printf("  Type: %s\n", project.Type)
+		cmd.Printf("  From Recipe: %s\n", *project.FromRecipe)
+		cmd.Printf("  Organization ID: %s\n", project.OrganizationId)
+		cmd.Printf("  Team ID: %s\n", project.TeamId)
+		cmd.Println()
+	}
+
+	if res.JSON200.PageInfo.HasNextPage {
+		cmd.Println("More projects available. Use pagination to see more.")
+	}
+
+	return nil
+}
+
+func getProject(cmd *cobra.Command, args []string) error {
+	projectID := args[0]
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	res, err := tempestClient.GetProjectWithResponse(context.TODO(), appapi.GetProjectJSONRequestBody{
+		Id: projectID,
+	})
+	if err != nil {
+		return fmt.Errorf("get project: %w", err)
+	}
+
+	if res.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", res.Status())
+	}
+
+	project := res.JSON200
+	cmd.Printf("Project Details:\n")
+	cmd.Printf("ID: %s\n", project.Id)
+	cmd.Printf("Name: %s\n", project.Name)
+	cmd.Printf("Type: %s\n", project.Type)
+	cmd.Printf("Organization ID: %s\n", project.OrganizationId)
+	cmd.Printf("Team ID: %s\n", project.TeamId)
+	cmd.Printf("Created: %s\n", project.CreatedAt.Format(time.RFC3339))
+	cmd.Printf("Updated: %s\n", project.UpdatedAt.Format(time.RFC3339))
+	cmd.Printf("From Recipe: %s\n", *project.FromRecipe)
+	cmd.Printf("Published: %v\n", *project.Published)
+
+	return nil
+}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -86,6 +86,8 @@ func listProjects(cmd *cobra.Command, args []string) error {
 		nextToken = &res.JSON200.Next
 	}
 
+	totalFetched := len(allProjects)
+
 	if limitFlag > 0 && len(allProjects) > limitFlag {
 		allProjects = allProjects[:limitFlag]
 	}
@@ -126,7 +128,6 @@ func listProjects(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	totalFetched := len(allProjects)
 	if limitFlag > 0 {
 		cmd.Printf("Showing %d/%d projects\n", len(allProjects), totalFetched)
 	} else {

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -58,7 +58,7 @@ func listProjects(cmd *cobra.Command, args []string) error {
 	var nextToken *string
 
 	for {
-		res, err := tempestClient.ProjectCollectionWithResponse(context.TODO(), appapi.ProjectCollectionJSONRequestBody{
+		res, err := tempestClient.PostProjectsListWithResponse(context.TODO(), appapi.PostProjectsListJSONRequestBody{
 			Next: nextToken,
 		})
 		if err != nil {
@@ -149,7 +149,7 @@ func getProject(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("create client: %w", err)
 	}
 
-	res, err := tempestClient.GetProjectWithResponse(context.TODO(), appapi.GetProjectJSONRequestBody{
+	res, err := tempestClient.PostProjectsGetWithResponse(context.TODO(), appapi.PostProjectsGetJSONRequestBody{
 		Id: projectID,
 	})
 	if err != nil {

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -94,11 +94,11 @@ func listProjects(cmd *cobra.Command, args []string) error {
 	table += "|----|------|------|-------------|-----------------|----------|\n"
 
 	for _, project := range projects {
-		fromRecipe := " "
+		var fromRecipe string
 		if project.FromRecipe != nil {
 			fromRecipe = *project.FromRecipe
 		}
-		teamID := " "
+		var teamID string
 		if project.TeamId != nil {
 			teamID = *project.TeamId
 		}
@@ -172,32 +172,60 @@ func getProject(cmd *cobra.Command, args []string) error {
 	project := res.JSON200
 
 	// Main Information
-	cmd.Printf("Name:\t%s\n", project.Name)
-	cmd.Printf("ID:\t%s\n", project.Id)
+	mainInfo := map[string]string{
+		"Name": project.Name,
+		"ID":   project.Id,
+	}
+
+	// Calculate the maximum key length for main information
+	maxMainInfoKeyLength := 0
+	for key := range mainInfo {
+		if len(key) > maxMainInfoKeyLength {
+			maxMainInfoKeyLength = len(key)
+		}
+	}
+
+	// Print each main information with aligned keys
+	for key, value := range mainInfo {
+		cmd.Printf("%-*s : %s\n", maxMainInfoKeyLength, key, value)
+	}
 	cmd.Println()
 
 	// Metadata
 	cmd.Println("Metadata:")
-	cmd.Printf("  Type:\t%s\n", project.Type)
-	cmd.Printf("  Organization ID:\t%s\n", project.OrganizationId)
-
 	teamID := "-"
 	if project.TeamId != nil {
 		teamID = *project.TeamId
 	}
-	cmd.Printf("  Team ID:\t%s\n", teamID)
-
 	createdAt := "-"
 	if project.CreatedAt != nil {
 		createdAt = project.CreatedAt.Format(time.RFC3339)
 	}
-	cmd.Printf("  Creation Timestamp:\t%s\n", createdAt)
-
 	updatedAt := "-"
 	if project.UpdatedAt != nil {
 		updatedAt = project.UpdatedAt.Format(time.RFC3339)
 	}
-	cmd.Printf("  Last Updated:\t%s\n", updatedAt)
+
+	metadata := map[string]string{
+		"Type":               project.Type,
+		"Organization ID":    project.OrganizationId,
+		"Team ID":            teamID,
+		"Creation Timestamp": createdAt,
+		"Last Updated":       updatedAt,
+	}
+
+	// Calculate the maximum key length for metadata
+	maxMetadataKeyLength := 0
+	for key := range metadata {
+		if len(key) > maxMetadataKeyLength {
+			maxMetadataKeyLength = len(key)
+		}
+	}
+
+	// Print each metadata with aligned keys
+	for key, value := range metadata {
+		cmd.Printf("  %-*s : %s\n", maxMetadataKeyLength, key, value)
+	}
 	cmd.Println()
 
 	// Status
@@ -206,13 +234,28 @@ func getProject(cmd *cobra.Command, args []string) error {
 	if project.Published != nil {
 		published = fmt.Sprintf("%v", *project.Published)
 	}
-	cmd.Printf("  Published:\t%s\n", published)
-
 	fromRecipe := "-"
 	if project.FromRecipe != nil {
 		fromRecipe = *project.FromRecipe
 	}
-	cmd.Printf("  From Recipe:\t%s\n", fromRecipe)
+
+	status := map[string]string{
+		"Published":   published,
+		"From Recipe": fromRecipe,
+	}
+
+	// Calculate the maximum key length for status
+	maxStatusKeyLength := 0
+	for key := range status {
+		if len(key) > maxStatusKeyLength {
+			maxStatusKeyLength = len(key)
+		}
+	}
+
+	// Print each status with aligned keys
+	for key, value := range status {
+		cmd.Printf("  %-*s : %s\n", maxStatusKeyLength, key, value)
+	}
 
 	return nil
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/charmbracelet/glamour"
@@ -178,16 +179,24 @@ func getProject(cmd *cobra.Command, args []string) error {
 		"ID":   project.Id,
 	}
 
+	// Extract and sort keys
+	mainInfoKeys := make([]string, 0, len(mainInfo))
+	for key := range mainInfo {
+		mainInfoKeys = append(mainInfoKeys, key)
+	}
+	sort.Strings(mainInfoKeys)
+
 	// Calculate the maximum key length for main information
 	maxMainInfoKeyLength := 0
-	for key := range mainInfo {
+	for _, key := range mainInfoKeys {
 		if len(key) > maxMainInfoKeyLength {
 			maxMainInfoKeyLength = len(key)
 		}
 	}
 
 	// Print each main information with aligned keys
-	for key, value := range mainInfo {
+	for _, key := range mainInfoKeys {
+		value := mainInfo[key]
 		cmd.Printf("%-*s : %s\n", maxMainInfoKeyLength, key, value)
 	}
 	cmd.Println()
@@ -215,16 +224,24 @@ func getProject(cmd *cobra.Command, args []string) error {
 		"Last Updated":       updatedAt,
 	}
 
+	// Extract and sort keys
+	metadataKeys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		metadataKeys = append(metadataKeys, key)
+	}
+	sort.Strings(metadataKeys)
+
 	// Calculate the maximum key length for metadata
 	maxMetadataKeyLength := 0
-	for key := range metadata {
+	for _, key := range metadataKeys {
 		if len(key) > maxMetadataKeyLength {
 			maxMetadataKeyLength = len(key)
 		}
 	}
 
 	// Print each metadata with aligned keys
-	for key, value := range metadata {
+	for _, key := range metadataKeys {
+		value := metadata[key]
 		cmd.Printf("  %-*s : %s\n", maxMetadataKeyLength, key, value)
 	}
 	cmd.Println()
@@ -245,16 +262,24 @@ func getProject(cmd *cobra.Command, args []string) error {
 		"From Recipe": fromRecipe,
 	}
 
+	// Extract and sort keys
+	statusKeys := make([]string, 0, len(status))
+	for key := range status {
+		statusKeys = append(statusKeys, key)
+	}
+	sort.Strings(statusKeys)
+
 	// Calculate the maximum key length for status
 	maxStatusKeyLength := 0
-	for key := range status {
+	for _, key := range statusKeys {
 		if len(key) > maxStatusKeyLength {
 			maxStatusKeyLength = len(key)
 		}
 	}
 
 	// Print each status with aligned keys
-	for key, value := range status {
+	for _, key := range statusKeys {
+		value := status[key]
 		cmd.Printf("  %-*s : %s\n", maxStatusKeyLength, key, value)
 	}
 

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -77,15 +77,14 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 
 		allRecipes = append(allRecipes, res.JSON200.Recipes...)
 
-		if limitFlag > 0 && len(allRecipes) >= limitFlag {
-			allRecipes = allRecipes[:limitFlag]
-			break
-		}
-
 		if res.JSON200.Next == "" {
 			break
 		}
 		nextToken = &res.JSON200.Next
+	}
+
+	if limitFlag > 0 && len(allRecipes) > limitFlag {
+		allRecipes = allRecipes[:limitFlag]
 	}
 
 	recipes := allRecipes
@@ -136,9 +135,11 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	totalCount := len(allRecipes)
+	totalFetched := len(allRecipes)
 	if limitFlag > 0 {
-		cmd.Printf("Showing %d of %d or more recipes\n", len(recipes), totalCount)
+		cmd.Printf("Showing %d/%d recipes\n", len(recipes), totalFetched)
+	} else {
+		cmd.Printf("Showing %d recipes\n", len(recipes))
 	}
 
 	return nil

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -94,19 +94,19 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	table += "|-------|------|------|---------|---------|-----------|-------------|\n"
 
 	for _, recipe := range recipes {
-		teamID := " "
+		var teamID string
 		if recipe.TeamId != nil {
 			teamID = *recipe.TeamId
 		}
-		public := " "
+		var public string
 		if recipe.Public != nil {
 			public = fmt.Sprintf("%v", *recipe.Public)
 		}
-		published := " "
+		var published string
 		if recipe.Published != nil {
 			published = fmt.Sprintf("%v", *recipe.Published)
 		}
-		publishedAt := " "
+		var publishedAt string
 		if recipe.PublishedAt != nil {
 			publishedAt = recipe.PublishedAt.Format(time.RFC3339)
 		}
@@ -182,9 +182,24 @@ func getRecipe(cmd *cobra.Command, args []string) error {
 	recipe := res.JSON200
 
 	// Main Information
-	cmd.Printf("Name:\t%s\n", recipe.Name)
-	cmd.Printf("ID:\t%s\n", recipe.Id)
-	cmd.Printf("Type:\t%s\n", recipe.Type)
+	mainInfo := map[string]string{
+		"Name": recipe.Name,
+		"ID":   recipe.Id,
+		"Type": recipe.Type,
+	}
+
+	// Calculate the maximum key length for main information
+	maxMainInfoKeyLength := 0
+	for key := range mainInfo {
+		if len(key) > maxMainInfoKeyLength {
+			maxMainInfoKeyLength = len(key)
+		}
+	}
+
+	// Print each main information with aligned keys
+	for key, value := range mainInfo {
+		cmd.Printf("%-*s : %s\n", maxMainInfoKeyLength, key, value)
+	}
 	cmd.Println()
 
 	// Metadata
@@ -193,19 +208,33 @@ func getRecipe(cmd *cobra.Command, args []string) error {
 	if recipe.TeamId != nil {
 		teamID = *recipe.TeamId
 	}
-	cmd.Printf("  Team ID:\t%s\n", teamID)
-
 	createdAt := "-"
 	if recipe.CreatedAt != nil {
 		createdAt = recipe.CreatedAt.Format(time.RFC3339)
 	}
-	cmd.Printf("  Creation Timestamp:\t%s\n", createdAt)
-
 	updatedAt := "-"
 	if recipe.UpdatedAt != nil {
 		updatedAt = recipe.UpdatedAt.Format(time.RFC3339)
 	}
-	cmd.Printf("  Last Updated:\t%s\n", updatedAt)
+
+	metadata := map[string]string{
+		"Team ID":            teamID,
+		"Creation Timestamp": createdAt,
+		"Last Updated":       updatedAt,
+	}
+
+	// Calculate the maximum key length for metadata
+	maxMetadataKeyLength := 0
+	for key := range metadata {
+		if len(key) > maxMetadataKeyLength {
+			maxMetadataKeyLength = len(key)
+		}
+	}
+
+	// Print each metadata with aligned keys
+	for key, value := range metadata {
+		cmd.Printf("  %-*s : %s\n", maxMetadataKeyLength, key, value)
+	}
 	cmd.Println()
 
 	// Status
@@ -214,19 +243,33 @@ func getRecipe(cmd *cobra.Command, args []string) error {
 	if recipe.Public != nil {
 		public = fmt.Sprintf("%v", *recipe.Public)
 	}
-	cmd.Printf("  Public:\t%s\n", public)
-
 	published := "-"
 	if recipe.Published != nil {
 		published = fmt.Sprintf("%v", *recipe.Published)
 	}
-	cmd.Printf("  Published:\t%s\n", published)
-
 	publishedAt := "-"
 	if recipe.PublishedAt != nil {
 		publishedAt = recipe.PublishedAt.Format(time.RFC3339)
 	}
-	cmd.Printf("  Published At:\t%s\n", publishedAt)
+
+	status := map[string]string{
+		"Public":       public,
+		"Published":    published,
+		"Published At": publishedAt,
+	}
+
+	// Calculate the maximum key length for status
+	maxStatusKeyLength := 0
+	for key := range status {
+		if len(key) > maxStatusKeyLength {
+			maxStatusKeyLength = len(key)
+		}
+	}
+
+	// Print each status with aligned keys
+	for key, value := range status {
+		cmd.Printf("  %-*s : %s\n", maxStatusKeyLength, key, value)
+	}
 
 	return nil
 }

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -58,7 +58,7 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	var nextToken *string
 
 	for {
-		res, err := tempestClient.RecipeCollectionWithResponse(context.TODO(), appapi.RecipeCollectionJSONRequestBody{
+		res, err := tempestClient.PostRecipesListWithResponse(context.TODO(), appapi.PostRecipesListJSONRequestBody{
 			Next: nextToken,
 		})
 		if err != nil {
@@ -159,7 +159,7 @@ func getRecipe(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("create client: %w", err)
 	}
 
-	res, err := tempestClient.GetRecipeWithResponse(context.TODO(), appapi.GetRecipeJSONRequestBody{
+	res, err := tempestClient.PostRecipesGetWithResponse(context.TODO(), appapi.PostRecipesGetJSONRequestBody{
 		Id: recipeID,
 	})
 	if err != nil {

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/tempestdx/cli/internal/secret"
+	appapi "github.com/tempestdx/openapi/app"
+)
+
+var recipeCmd = &cobra.Command{
+	Use:   "recipe",
+	Short: "Manage recipes",
+	Long:  `List and get recipes from your Tempest App`,
+}
+
+var recipeListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all recipes",
+	Args:  cobra.NoArgs,
+	RunE:  listRecipes,
+}
+
+var recipeGetCmd = &cobra.Command{
+	Use:   "get <recipe_id>",
+	Short: "Get a specific recipe",
+	Args:  cobra.ExactArgs(1),
+	RunE:  getRecipe,
+}
+
+func init() {
+	rootCmd.AddCommand(recipeCmd)
+	recipeCmd.AddCommand(recipeListCmd)
+	recipeCmd.AddCommand(recipeGetCmd)
+}
+
+func listRecipes(cmd *cobra.Command, args []string) error {
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	res, err := tempestClient.RecipeCollectionWithResponse(context.TODO(), appapi.RecipeCollectionJSONRequestBody{
+		After: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("list recipes: %w", err)
+	}
+
+	if res.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", res.Status())
+	}
+
+	cmd.Println("Recipes:")
+	for _, edge := range res.JSON200.Edges {
+		recipe := edge.Node
+		cmd.Printf("- ID: %s\n", recipe.Id)
+		cmd.Printf("  Name: %s\n", recipe.Name)
+		cmd.Printf("  Type: %s\n", recipe.Type)
+		if recipe.PublishedAt != nil {
+			cmd.Printf("  Published: %s\n", recipe.PublishedAt.Format(time.RFC3339))
+		}
+		cmd.Println()
+	}
+
+	if res.JSON200.PageInfo.HasNextPage {
+		cmd.Println("More recipes available. Use pagination to see more.")
+	}
+
+	return nil
+}
+
+func getRecipe(cmd *cobra.Command, args []string) error {
+	recipeID := args[0]
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	res, err := tempestClient.GetRecipeWithResponse(context.TODO(), appapi.GetRecipeJSONRequestBody{
+		Id: recipeID,
+	})
+	if err != nil {
+		return fmt.Errorf("get recipe: %w", err)
+	}
+
+	if res.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", res.Status())
+	}
+
+	recipe := res.JSON200
+	cmd.Printf("Recipe Details:\n")
+	cmd.Printf("ID: %s\n", recipe.Id)
+	cmd.Printf("Name: %s\n", recipe.Name)
+	cmd.Printf("Type: %s\n", recipe.Type)
+	cmd.Printf("Team ID: %s\n", recipe.TeamId)
+	cmd.Printf("Created: %s\n", recipe.CreatedAt.Format(time.RFC3339))
+	cmd.Printf("Updated: %s\n", recipe.UpdatedAt.Format(time.RFC3339))
+	cmd.Printf("Public: %v\n", recipe.Public)
+	cmd.Printf("Published: %v\n", recipe.Published)
+	if recipe.PublishedAt != nil {
+		cmd.Printf("Published At: %s\n", recipe.PublishedAt.Format(time.RFC3339))
+	}
+
+	return nil
+}

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/charmbracelet/glamour"
@@ -189,16 +190,24 @@ func getRecipe(cmd *cobra.Command, args []string) error {
 		"Type": recipe.Type,
 	}
 
+	// Extract and sort keys
+	mainInfoKeys := make([]string, 0, len(mainInfo))
+	for key := range mainInfo {
+		mainInfoKeys = append(mainInfoKeys, key)
+	}
+	sort.Strings(mainInfoKeys)
+
 	// Calculate the maximum key length for main information
 	maxMainInfoKeyLength := 0
-	for key := range mainInfo {
+	for _, key := range mainInfoKeys {
 		if len(key) > maxMainInfoKeyLength {
 			maxMainInfoKeyLength = len(key)
 		}
 	}
 
 	// Print each main information with aligned keys
-	for key, value := range mainInfo {
+	for _, key := range mainInfoKeys {
+		value := mainInfo[key]
 		cmd.Printf("%-*s : %s\n", maxMainInfoKeyLength, key, value)
 	}
 	cmd.Println()
@@ -224,16 +233,24 @@ func getRecipe(cmd *cobra.Command, args []string) error {
 		"Last Updated":       updatedAt,
 	}
 
+	// Extract and sort keys
+	keys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
 	// Calculate the maximum key length for metadata
 	maxMetadataKeyLength := 0
-	for key := range metadata {
+	for _, key := range keys {
 		if len(key) > maxMetadataKeyLength {
 			maxMetadataKeyLength = len(key)
 		}
 	}
 
 	// Print each metadata with aligned keys
-	for key, value := range metadata {
+	for _, key := range keys {
+		value := metadata[key]
 		cmd.Printf("  %-*s : %s\n", maxMetadataKeyLength, key, value)
 	}
 	cmd.Println()
@@ -259,16 +276,24 @@ func getRecipe(cmd *cobra.Command, args []string) error {
 		"Published At": publishedAt,
 	}
 
+	// Extract and sort keys
+	statusKeys := make([]string, 0, len(status))
+	for key := range status {
+		statusKeys = append(statusKeys, key)
+	}
+	sort.Strings(statusKeys)
+
 	// Calculate the maximum key length for status
 	maxStatusKeyLength := 0
-	for key := range status {
+	for _, key := range statusKeys {
 		if len(key) > maxStatusKeyLength {
 			maxStatusKeyLength = len(key)
 		}
 	}
 
 	// Print each status with aligned keys
-	for key, value := range status {
+	for _, key := range statusKeys {
+		value := status[key]
 		cmd.Printf("  %-*s : %s\n", maxStatusKeyLength, key, value)
 	}
 

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/charmbracelet/glamour"
 	"github.com/spf13/cobra"
 	"github.com/tempestdx/cli/internal/secret"
 	appapi "github.com/tempestdx/openapi/app"
@@ -35,6 +36,10 @@ func init() {
 	rootCmd.AddCommand(recipeCmd)
 	recipeCmd.AddCommand(recipeListCmd)
 	recipeCmd.AddCommand(recipeGetCmd)
+
+	recipeListCmd.Flags().IntVar(&headFlag, "head", 0, "Show first n recipes")
+	recipeListCmd.Flags().IntVar(&tailFlag, "tail", 0, "Show last n recipes")
+	recipeListCmd.MarkFlagsMutuallyExclusive("head", "tail")
 }
 
 func listRecipes(cmd *cobra.Command, args []string) error {
@@ -52,7 +57,7 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	}
 
 	res, err := tempestClient.RecipeCollectionWithResponse(context.TODO(), appapi.RecipeCollectionJSONRequestBody{
-		After: nil,
+		Next: nil,
 	})
 	if err != nil {
 		return fmt.Errorf("list recipes: %w", err)
@@ -62,20 +67,66 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unexpected response: %s", res.Status())
 	}
 
-	cmd.Println("Recipes:")
-	for _, edge := range res.JSON200.Edges {
-		recipe := edge.Node
-		cmd.Printf("- ID: %s\n", recipe.Id)
-		cmd.Printf("  Name: %s\n", recipe.Name)
-		cmd.Printf("  Type: %s\n", recipe.Type)
-		if recipe.PublishedAt != nil {
-			cmd.Printf("  Published: %s\n", recipe.PublishedAt.Format(time.RFC3339))
-		}
-		cmd.Println()
+	recipes := res.JSON200.Recipes
+	if headFlag > 0 && headFlag < len(recipes) {
+		recipes = recipes[:headFlag]
+	} else if tailFlag > 0 && tailFlag < len(recipes) {
+		recipes = recipes[len(recipes)-tailFlag:]
 	}
 
-	if res.JSON200.PageInfo.HasNextPage {
-		cmd.Println("More recipes available. Use pagination to see more.")
+	table := "| ID | Name | Type | Team ID | Public | Published | Published At |\n"
+	table += "|-------|------|------|---------|---------|-----------|-------------|\n"
+
+	for _, recipe := range recipes {
+		teamID := " "
+		if recipe.TeamId != nil {
+			teamID = *recipe.TeamId
+		}
+		public := " "
+		if recipe.Public != nil {
+			public = fmt.Sprintf("%v", *recipe.Public)
+		}
+		published := " "
+		if recipe.Published != nil {
+			published = fmt.Sprintf("%v", *recipe.Published)
+		}
+		publishedAt := " "
+		if recipe.PublishedAt != nil {
+			publishedAt = recipe.PublishedAt.Format(time.RFC3339)
+		}
+
+		table += fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s |\n",
+			recipe.Id,
+			recipe.Name,
+			recipe.Type,
+			teamID,
+			public,
+			published,
+			publishedAt,
+		)
+	}
+
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(120),
+	)
+	if err != nil {
+		return fmt.Errorf("create renderer: %w", err)
+	}
+
+	out, err := renderer.Render(table)
+	if err != nil {
+		return fmt.Errorf("render table: %w", err)
+	}
+	cmd.Print(out)
+
+	totalCount := len(res.JSON200.Recipes)
+	if headFlag > 0 || tailFlag > 0 {
+		cmd.Printf("Showing %d of %d recipes\n", len(recipes), totalCount)
+	}
+
+	if res.JSON200.Next != "" {
+		cmd.Printf("More recipes available. Use --after %s to see more.\n", res.JSON200.Next)
 	}
 
 	return nil
@@ -108,17 +159,36 @@ func getRecipe(cmd *cobra.Command, args []string) error {
 	}
 
 	recipe := res.JSON200
-	cmd.Printf("Recipe Details:\n")
-	cmd.Printf("ID: %s\n", recipe.Id)
-	cmd.Printf("Name: %s\n", recipe.Name)
-	cmd.Printf("Type: %s\n", recipe.Type)
-	cmd.Printf("Team ID: %s\n", recipe.TeamId)
-	cmd.Printf("Created: %s\n", recipe.CreatedAt.Format(time.RFC3339))
-	cmd.Printf("Updated: %s\n", recipe.UpdatedAt.Format(time.RFC3339))
-	cmd.Printf("Public: %v\n", recipe.Public)
-	cmd.Printf("Published: %v\n", recipe.Published)
+
+	// Main Information (required fields from the schema)
+	cmd.Printf("Name:\t%s\n", recipe.Name)
+	cmd.Printf("ID:\t%s\n", recipe.Id)
+	cmd.Printf("Type:\t%s\n", recipe.Type)
+	cmd.Println()
+
+	// Metadata
+	cmd.Println("Metadata:")
+	if recipe.TeamId != nil {
+		cmd.Printf("  Team ID:\t%s\n", *recipe.TeamId)
+	}
+	if recipe.CreatedAt != nil {
+		cmd.Printf("  Creation Timestamp:\t%s\n", recipe.CreatedAt.Format(time.RFC3339))
+	}
+	if recipe.UpdatedAt != nil {
+		cmd.Printf("  Last Updated:\t%s\n", recipe.UpdatedAt.Format(time.RFC3339))
+	}
+	cmd.Println()
+
+	// Status
+	cmd.Println("Status:")
+	if recipe.Public != nil {
+		cmd.Printf("  Public:\t%v\n", *recipe.Public)
+	}
+	if recipe.Published != nil {
+		cmd.Printf("  Published:\t%v\n", *recipe.Published)
+	}
 	if recipe.PublishedAt != nil {
-		cmd.Printf("Published At: %s\n", recipe.PublishedAt.Format(time.RFC3339))
+		cmd.Printf("  Published At:\t%s\n", recipe.PublishedAt.Format(time.RFC3339))
 	}
 
 	return nil

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -84,6 +84,8 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 		nextToken = &res.JSON200.Next
 	}
 
+	totalFetched := len(allRecipes)
+
 	if limitFlag > 0 && len(allRecipes) > limitFlag {
 		allRecipes = allRecipes[:limitFlag]
 	}
@@ -136,7 +138,6 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	totalFetched := len(allRecipes)
 	if limitFlag > 0 {
 		cmd.Printf("Showing %d/%d recipes\n", len(recipes), totalFetched)
 	} else {

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -37,9 +37,7 @@ func init() {
 	recipeCmd.AddCommand(recipeListCmd)
 	recipeCmd.AddCommand(recipeGetCmd)
 
-	recipeListCmd.Flags().IntVar(&headFlag, "head", 0, "Show first n recipes")
-	recipeListCmd.Flags().IntVar(&tailFlag, "tail", 0, "Show last n recipes")
-	recipeListCmd.MarkFlagsMutuallyExclusive("head", "tail")
+	recipeListCmd.Flags().IntVar(&limitFlag, "limit", 0, "Limit the number of recipes shown")
 }
 
 func listRecipes(cmd *cobra.Command, args []string) error {
@@ -79,6 +77,11 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 
 		allRecipes = append(allRecipes, res.JSON200.Recipes...)
 
+		if limitFlag > 0 && len(allRecipes) >= limitFlag {
+			allRecipes = allRecipes[:limitFlag]
+			break
+		}
+
 		if res.JSON200.Next == "" {
 			break
 		}
@@ -86,11 +89,6 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	}
 
 	recipes := allRecipes
-	if headFlag > 0 && headFlag < len(recipes) {
-		recipes = recipes[:headFlag]
-	} else if tailFlag > 0 && tailFlag < len(recipes) {
-		recipes = recipes[len(recipes)-tailFlag:]
-	}
 
 	table := "| ID | Name | Type | Team ID | Public | Published | Published At |\n"
 	table += "|-------|------|------|---------|---------|-----------|-------------|\n"
@@ -139,8 +137,8 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	cmd.Print(out)
 
 	totalCount := len(allRecipes)
-	if headFlag > 0 || tailFlag > 0 {
-		cmd.Printf("Showing %d of %d recipes\n", len(recipes), totalCount)
+	if limitFlag > 0 {
+		cmd.Printf("Showing %d of %d or more recipes\n", len(recipes), totalCount)
 	}
 
 	return nil

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -86,6 +86,8 @@ func listResources(cmd *cobra.Command, args []string) error {
 		nextToken = &res.JSON200.Next
 	}
 
+	totalFetched := len(allResources)
+
 	if limitFlag > 0 && len(allResources) > limitFlag {
 		allResources = allResources[:limitFlag]
 	}
@@ -127,7 +129,6 @@ func listResources(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	totalFetched := len(allResources)
 	if limitFlag > 0 {
 		cmd.Printf("Showing %d/%d resources\n", len(resources), totalFetched)
 	} else {

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -64,7 +64,6 @@ func listResources(cmd *cobra.Command, args []string) error {
 	for {
 		res, err := tempestClient.ResourceCollectionWithResponse(context.TODO(), appapi.ResourceCollectionJSONRequestBody{
 			Next:        nextToken,
-			RequestType: "list_resources",
 		})
 		if err != nil {
 			return fmt.Errorf("list resources: %w", err)

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/tempestdx/cli/internal/secret"
+	appapi "github.com/tempestdx/openapi/app"
+)
+
+var resourceCmd = &cobra.Command{
+	Use:   "resource",
+	Short: "Manage resources",
+	Long:  `List and get resources from your Tempest App`,
+}
+
+var resourceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all resources",
+	Args:  cobra.NoArgs,
+	RunE:  listResources,
+}
+
+var resourceGetCmd = &cobra.Command{
+	Use:   "get <resource_id>",
+	Short: "Get a specific resource",
+	Args:  cobra.ExactArgs(1),
+	RunE:  getResource,
+}
+
+func init() {
+	rootCmd.AddCommand(resourceCmd)
+	resourceCmd.AddCommand(resourceListCmd)
+	resourceCmd.AddCommand(resourceGetCmd)
+}
+
+func listResources(cmd *cobra.Command, args []string) error {
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	res, err := tempestClient.ResourceCollectionWithResponse(context.TODO(), appapi.ResourceCollectionJSONRequestBody{
+		Next:        "",
+		RequestType: "list_resources",
+	})
+	if err != nil {
+		return fmt.Errorf("list resources: %w", err)
+	}
+
+	if res.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", res.Status())
+	}
+
+	cmd.Println("Resources:")
+	for _, resource := range res.JSON200.Resources {
+		cmd.Printf("- ID: %s\n", resource.Id)
+		cmd.Printf("  Name: %s\n", *resource.Name)
+		cmd.Printf("  Type: %s\n", *resource.Type)
+		if resource.OrganizationId != nil {
+			cmd.Printf("  Organization ID: %s\n", *resource.OrganizationId)
+		}
+		cmd.Println()
+	}
+
+	if res.JSON200.Next != "" {
+		cmd.Println("More resources available. Use pagination to see more.")
+	}
+
+	return nil
+}
+
+func getResource(cmd *cobra.Command, args []string) error {
+	resourceID := args[0]
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	body := appapi.GetResourcesJSONRequestBody{Id: resourceID}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal request body: %w", err)
+	}
+
+	res, err := tempestClient.GetResourcesWithBodyWithResponse(context.TODO(), "POST", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("get resource: %w", err)
+	}
+
+	if res.JSON200 == nil {
+		return fmt.Errorf("unexpected response: %s", res.Status())
+	}
+
+	resource := res.JSON200
+	cmd.Printf("Resource Details:\n")
+	cmd.Printf("ID: %s\n", resource.Id)
+	cmd.Printf("Name: %s\n", *resource.Name)
+	if resource.Type != nil {
+		cmd.Printf("Type: %s\n", *resource.Type)
+	}
+	if resource.OrganizationId != nil {
+		cmd.Printf("Organization ID: %s\n", *resource.OrganizationId)
+	}
+	cmd.Printf("Created: %s\n", resource.CreatedAt.Format(time.RFC3339))
+	cmd.Printf("Updated: %s\n", resource.UpdatedAt.Format(time.RFC3339))
+
+	return nil
+}

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -59,7 +59,7 @@ func listResources(cmd *cobra.Command, args []string) error {
 	}
 
 	var allResources []appapi.Resource
-	var nextToken string
+	var nextToken *string
 
 	for {
 		res, err := tempestClient.ResourceCollectionWithResponse(context.TODO(), appapi.ResourceCollectionJSONRequestBody{
@@ -84,7 +84,7 @@ func listResources(cmd *cobra.Command, args []string) error {
 		if res.JSON200.Next == "" {
 			break
 		}
-		nextToken = res.JSON200.Next
+		nextToken = &res.JSON200.Next
 	}
 
 	resources := allResources

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -219,7 +219,7 @@ func getResource(cmd *cobra.Command, args []string) error {
 	// Define the fields for the initial section
 	initialFields := map[string]string{
 		"Name":         name,
-		"ID":           resource.Id,
+		"ID":           *resource.Id,
 		"External ID":  externalID,
 		"External URL": externalURL,
 	}

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -60,7 +60,7 @@ func listResources(cmd *cobra.Command, args []string) error {
 	var nextToken *string
 
 	for {
-		res, err := tempestClient.ResourceCollectionWithResponse(context.TODO(), appapi.ResourceCollectionJSONRequestBody{
+		res, err := tempestClient.PostResourcesListWithResponse(context.TODO(), appapi.PostResourcesListJSONRequestBody{
 			Next: nextToken,
 		})
 		if err != nil {
@@ -150,13 +150,13 @@ func getResource(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("create client: %w", err)
 	}
 
-	body := appapi.GetResourcesJSONRequestBody{Id: resourceID}
+	body := appapi.PostResourcesGetJSONRequestBody{Id: resourceID}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("marshal request body: %w", err)
 	}
 
-	res, err := tempestClient.GetResourcesWithBodyWithResponse(context.TODO(), "POST", bytes.NewReader(bodyBytes))
+	res, err := tempestClient.PostResourcesGetWithBodyWithResponse(context.TODO(), "POST", bytes.NewReader(bodyBytes))
 	if err != nil {
 		return fmt.Errorf("get resource: %w", err)
 	}

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -79,15 +79,14 @@ func listResources(cmd *cobra.Command, args []string) error {
 
 		allResources = append(allResources, res.JSON200.Resources...)
 
-		if limitFlag > 0 && len(allResources) >= limitFlag {
-			allResources = allResources[:limitFlag]
-			break
-		}
-
 		if res.JSON200.Next == "" {
 			break
 		}
 		nextToken = &res.JSON200.Next
+	}
+
+	if limitFlag > 0 && len(allResources) > limitFlag {
+		allResources = allResources[:limitFlag]
 	}
 
 	resources := allResources
@@ -127,9 +126,11 @@ func listResources(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	totalCount := len(allResources)
+	totalFetched := len(allResources)
 	if limitFlag > 0 {
-		cmd.Printf("Showing %d of %d or more resources\n", len(resources), totalCount)
+		cmd.Printf("Showing %d/%d resources\n", len(resources), totalFetched)
+	} else {
+		cmd.Printf("Showing %d resources\n", len(resources))
 	}
 
 	return nil

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -58,19 +58,37 @@ func listResources(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("create client: %w", err)
 	}
 
-	res, err := tempestClient.ResourceCollectionWithResponse(context.TODO(), appapi.ResourceCollectionJSONRequestBody{
-		Next:        "",
-		RequestType: "list_resources",
-	})
-	if err != nil {
-		return fmt.Errorf("list resources: %w", err)
+	var allResources []appapi.Resource
+	var nextToken string
+
+	for {
+		res, err := tempestClient.ResourceCollectionWithResponse(context.TODO(), appapi.ResourceCollectionJSONRequestBody{
+			Next:        nextToken,
+			RequestType: "list_resources",
+		})
+		if err != nil {
+			return fmt.Errorf("list resources: %w", err)
+		}
+
+		if res.JSON200 == nil {
+			if res.JSON400 != nil {
+				return fmt.Errorf("bad request: %s", res.JSON400.Error)
+			}
+			if res.JSON500 != nil {
+				return fmt.Errorf("server error: %s", res.JSON500.Error)
+			}
+			return fmt.Errorf("unexpected response: %s", res.Status())
+		}
+
+		allResources = append(allResources, res.JSON200.Resources...)
+
+		if res.JSON200.Next == "" {
+			break
+		}
+		nextToken = res.JSON200.Next
 	}
 
-	if res.JSON200 == nil {
-		return fmt.Errorf("unexpected response: %s", res.Status())
-	}
-
-	resources := res.JSON200.Resources
+	resources := allResources
 	if headFlag > 0 && headFlag < len(resources) {
 		resources = resources[:headFlag]
 	} else if tailFlag > 0 && tailFlag < len(resources) {
@@ -112,13 +130,9 @@ func listResources(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	totalCount := len(res.JSON200.Resources)
+	totalCount := len(allResources)
 	if headFlag > 0 || tailFlag > 0 {
 		cmd.Printf("Showing %d of %d resources\n", len(resources), totalCount)
-	}
-
-	if res.JSON200.Next != "" {
-		cmd.Println("More resources available. Use pagination to see more.")
 	}
 
 	return nil
@@ -151,56 +165,88 @@ func getResource(cmd *cobra.Command, args []string) error {
 	}
 
 	if res.JSON200 == nil {
+		if res.JSON400 != nil {
+			return fmt.Errorf("bad request: %s", res.JSON400.Error)
+		}
+		if res.JSON404 != nil {
+			return fmt.Errorf("not found: %s", res.JSON404.Error)
+		}
+		if res.JSON500 != nil {
+			return fmt.Errorf("server error: %s", res.JSON500.Error)
+		}
 		return fmt.Errorf("unexpected response: %s", res.Status())
 	}
 
 	resource := res.JSON200
-	name := " "
+	name := "-"
 	if resource.Name != nil {
 		name = *resource.Name
 	}
 
 	cmd.Printf("Name:\t%s\n", name)
 	cmd.Printf("ID:\t%s\n", resource.Id)
+	externalID := "-"
 	if resource.ExternalId != "" {
-		cmd.Printf("External ID:\t%s\n", resource.ExternalId)
+		externalID = resource.ExternalId
 	}
+	cmd.Printf("External ID:\t%s\n", externalID)
+
+	externalURL := "-"
 	if resource.ExternalUrl != nil {
-		cmd.Printf("External URL:\t%s\n", *resource.ExternalUrl)
+		externalURL = *resource.ExternalUrl
 	}
+	cmd.Printf("External URL:\t%s\n", externalURL)
 	cmd.Println()
 
 	cmd.Println("Metadata:")
 	cmd.Printf("  Type:\t%s\n", resource.Type)
+	orgID := "-"
 	if resource.OrganizationId != nil {
-		cmd.Printf("  Organization ID:\t%s\n", *resource.OrganizationId)
+		orgID = *resource.OrganizationId
 	}
+	cmd.Printf("  Organization ID:\t%s\n", orgID)
+
+	createdBy := "-"
 	if resource.CreatedBy != nil {
-		cmd.Printf("  Created By:\t%s\n", *resource.CreatedBy)
+		createdBy = *resource.CreatedBy
 	}
+	cmd.Printf("  Created By:\t%s\n", createdBy)
+
+	createdAt := "-"
 	if resource.CreatedAt != nil {
-		cmd.Printf("  Creation Timestamp:\t%s\n", resource.CreatedAt.Format(time.RFC3339))
+		createdAt = resource.CreatedAt.Format(time.RFC3339)
 	}
+	cmd.Printf("  Creation Timestamp:\t%s\n", createdAt)
+
+	updatedAt := "-"
 	if resource.UpdatedAt != nil {
-		cmd.Printf("  Last Updated:\t%s\n", resource.UpdatedAt.Format(time.RFC3339))
+		updatedAt = resource.UpdatedAt.Format(time.RFC3339)
 	}
+	cmd.Printf("  Last Updated:\t%s\n", updatedAt)
+
+	syncedAt := "-"
 	if resource.SyncedAt != nil {
-		cmd.Printf("  Last Synced:\t%s\n", resource.SyncedAt.Format(time.RFC3339))
+		syncedAt = resource.SyncedAt.Format(time.RFC3339)
 	}
+	cmd.Printf("  Last Synced:\t%s\n", syncedAt)
 	cmd.Println()
 
-	if resource.Properties != nil {
-		cmd.Println("Properties:")
+	cmd.Println("Properties:")
+	if resource.Properties != nil && len(*resource.Properties) > 0 {
 		for key, value := range *resource.Properties {
 			cmd.Printf("  %s:\t%v\n", key, value)
 		}
-		cmd.Println()
+	} else {
+		cmd.Printf("  -\n")
 	}
+	cmd.Println()
 
+	cmd.Println("Status:")
+	status := "-"
 	if resource.Status != nil {
-		cmd.Println("Status:")
-		cmd.Printf("  Status:\t%s\n", *resource.Status)
+		status = *resource.Status
 	}
+	cmd.Printf("  Status:\t%s\n", status)
 
 	return nil
 }

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -105,7 +105,7 @@ func listResources(cmd *cobra.Command, args []string) error {
 		}
 
 		table += fmt.Sprintf("| %s | %s | %s | %s |\n",
-			resource.Id,
+			*resource.Id,
 			name,
 			resource.Type,
 			orgID,
@@ -212,7 +212,7 @@ func getResource(cmd *cobra.Command, args []string) error {
 	}
 
 	externalURL := "-"
-	if resource.ExternalUrl != nil {
+	if resource.ExternalUrl != nil && *resource.ExternalUrl != "" {
 		externalURL = *resource.ExternalUrl
 	}
 

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -96,11 +96,11 @@ func listResources(cmd *cobra.Command, args []string) error {
 	table += "|-------|------|------|----------------|\n"
 
 	for _, resource := range resources {
-		name := " "
+		var name string
 		if resource.Name != nil {
 			name = *resource.Name
 		}
-		orgID := " "
+		var orgID string
 		if resource.OrganizationId != nil {
 			orgID = *resource.OrganizationId
 		}
@@ -180,70 +180,111 @@ func getResource(cmd *cobra.Command, args []string) error {
 		name = *resource.Name
 	}
 
-	cmd.Printf("Name:\t%s\n", name)
-	cmd.Printf("ID:\t%s\n", resource.Id)
-	externalID := "-"
-	if resource.ExternalId != "" {
-		externalID = resource.ExternalId
-	}
-	cmd.Printf("External ID:\t%s\n", externalID)
-
-	externalURL := "-"
-	if resource.ExternalUrl != nil {
-		externalURL = *resource.ExternalUrl
-	}
-	cmd.Printf("External URL:\t%s\n", externalURL)
-	cmd.Println()
-
-	cmd.Println("Metadata:")
-	cmd.Printf("  Type:\t%s\n", resource.Type)
 	orgID := "-"
 	if resource.OrganizationId != nil {
 		orgID = *resource.OrganizationId
 	}
-	cmd.Printf("  Organization ID:\t%s\n", orgID)
 
 	createdBy := "-"
 	if resource.CreatedBy != nil {
 		createdBy = *resource.CreatedBy
 	}
-	cmd.Printf("  Created By:\t%s\n", createdBy)
 
 	createdAt := "-"
 	if resource.CreatedAt != nil {
 		createdAt = resource.CreatedAt.Format(time.RFC3339)
 	}
-	cmd.Printf("  Creation Timestamp:\t%s\n", createdAt)
 
 	updatedAt := "-"
 	if resource.UpdatedAt != nil {
 		updatedAt = resource.UpdatedAt.Format(time.RFC3339)
 	}
-	cmd.Printf("  Last Updated:\t%s\n", updatedAt)
 
 	syncedAt := "-"
 	if resource.SyncedAt != nil {
 		syncedAt = resource.SyncedAt.Format(time.RFC3339)
 	}
-	cmd.Printf("  Last Synced:\t%s\n", syncedAt)
+
+	externalID := "-"
+	if resource.ExternalId != "" {
+		externalID = resource.ExternalId
+	}
+
+	externalURL := "-"
+	if resource.ExternalUrl != nil {
+		externalURL = *resource.ExternalUrl
+	}
+
+	// Define the fields for the initial section
+	initialFields := map[string]string{
+		"Name":         name,
+		"ID":           resource.Id,
+		"External ID":  externalID,
+		"External URL": externalURL,
+	}
+
+	// Calculate the maximum key length for the initial fields
+	maxInitialKeyLength := 0
+	for key := range initialFields {
+		if len(key) > maxInitialKeyLength {
+			maxInitialKeyLength = len(key)
+		}
+	}
+
+	// Print each initial field with aligned keys
+	for key, value := range initialFields {
+		cmd.Printf("%-*s : %-30s\n", maxInitialKeyLength, key, value)
+	}
+	cmd.Println()
+
+	cmd.Println("Metadata:")
+	metadata := map[string]string{
+		"Type":               resource.Type,
+		"Organization ID":    orgID,
+		"Created By":         createdBy,
+		"Creation Timestamp": createdAt,
+		"Last Updated":       updatedAt,
+		"Last Synced":        syncedAt,
+	}
+
+	// Calculate the maximum key length for metadata
+	maxMetadataKeyLength := 0
+	for key := range metadata {
+		if len(key) > maxMetadataKeyLength {
+			maxMetadataKeyLength = len(key)
+		}
+	}
+
+	// Print each metadata with aligned keys
+	for key, value := range metadata {
+		cmd.Printf("  %-*s : %-30s\n", maxMetadataKeyLength, key, value)
+	}
 	cmd.Println()
 
 	cmd.Println("Properties:")
 	if resource.Properties != nil && len(*resource.Properties) > 0 {
+		// Calculate the maximum key length for properties
+		maxPropertyKeyLength := 0
+		for key := range *resource.Properties {
+			if len(key) > maxPropertyKeyLength {
+				maxPropertyKeyLength = len(key)
+			}
+		}
+
+		// Print each property with aligned keys
 		for key, value := range *resource.Properties {
-			cmd.Printf("  %s:\t%v\n", key, value)
+			cmd.Printf("  %-*s : %-30v\n", maxPropertyKeyLength, key, value)
 		}
 	} else {
 		cmd.Printf("  -\n")
 	}
 	cmd.Println()
 
-	cmd.Println("Status:")
 	status := "-"
 	if resource.Status != nil {
 		status = *resource.Status
 	}
-	cmd.Printf("  Status:\t%s\n", status)
+	cmd.Printf("%-*s: %-30s\n", len("Status"), "Status", status)
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,10 @@ var (
 	tokenStore  secret.TokenStore
 	debugMode   bool
 
+	headFlag int
+	tailFlag int
+
+
 	rootCmd = &cobra.Command{
 		Use:     "tempest [command] [flags]",
 		Short:   "Tempest is a CLI tool to interact with the Tempest API and SDK",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,8 +16,7 @@ var (
 	tokenStore  secret.TokenStore
 	debugMode   bool
 
-	headFlag int
-	tailFlag int
+	limitFlag int
 
 
 	rootCmd = &cobra.Command{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -232,7 +232,7 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 				ctx, cancel := context.WithTimeout(context.Background(), appExecutionTimeout)
 				res, err := runner.Client.ExecuteResourceOperation(ctx, connect.NewRequest(&appv1.ExecuteResourceOperationRequest{
 					Resource: &appv1.Resource{
-						Type:       v.Resource.Type,
+						Type:       *v.Resource.Type,
 						ExternalId: v.Resource.ExternalId,
 					},
 					Operation:            op,
@@ -256,7 +256,7 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 				var response appapi.ReportResponse_Response
 
 				resource := appapi.Resource{
-					Type:        res.Msg.Resource.Type,
+					Type:        &res.Msg.Resource.Type,
 					ExternalId:  res.Msg.Resource.ExternalId,
 					DisplayName: res.Msg.Resource.DisplayName,
 				}
@@ -318,7 +318,7 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				res, err := runner.Client.ListResources(ctx, connect.NewRequest(&appv1.ListResourcesRequest{
 					Resource: &appv1.Resource{
-						Type: v.Resource.Type,
+						Type: *v.Resource.Type,
 					},
 					Next:     v.Next,
 					Metadata: metadata,
@@ -349,7 +349,7 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 						ExternalId:  r.ExternalId,
 						DisplayName: r.DisplayName,
 						Properties:  &properties,
-						Type:        r.Type,
+						Type:        &r.Type,
 						Links: &appapi.Links{
 							Links: &items,
 						},

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -232,7 +232,7 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 				ctx, cancel := context.WithTimeout(context.Background(), appExecutionTimeout)
 				res, err := runner.Client.ExecuteResourceOperation(ctx, connect.NewRequest(&appv1.ExecuteResourceOperationRequest{
 					Resource: &appv1.Resource{
-						Type:       *v.Resource.Type,
+						Type:       v.Resource.Type,
 						ExternalId: v.Resource.ExternalId,
 					},
 					Operation:            op,
@@ -256,7 +256,7 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 				var response appapi.ReportResponse_Response
 
 				resource := appapi.Resource{
-					Type:        &res.Msg.Resource.Type,
+					Type:        res.Msg.Resource.Type,
 					ExternalId:  res.Msg.Resource.ExternalId,
 					DisplayName: res.Msg.Resource.DisplayName,
 				}
@@ -318,7 +318,7 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				res, err := runner.Client.ListResources(ctx, connect.NewRequest(&appv1.ListResourcesRequest{
 					Resource: &appv1.Resource{
-						Type: *v.Resource.Type,
+						Type: v.Resource.Type,
 					},
 					Next:     v.Next,
 					Metadata: metadata,
@@ -349,7 +349,7 @@ func startPolling(runner runner.Runner, tempestClient *appapi.ClientWithResponse
 						ExternalId:  r.ExternalId,
 						DisplayName: r.DisplayName,
 						Properties:  &properties,
-						Type:        &r.Type,
+						Type:        r.Type,
 						Links: &appapi.Links{
 							Links: &items,
 						},

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/glamour v0.8.0
-	github.com/spf13/cobra v1.8.1
+	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tempestdx/openapi v0.1.3
 	github.com/tempestdx/protobuf v0.1.3
@@ -26,7 +26,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/lipgloss v0.12.1 // indirect
 	github.com/charmbracelet/x/ansi v0.1.4 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
@@ -48,7 +48,7 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/yuin/goldmark v1.7.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	github.com/tempestdx/openapi v0.1.4-0.20250214031059-8fe414f76597
+	github.com/tempestdx/openapi v0.1.4
 	github.com/tempestdx/protobuf v0.1.3
 	github.com/tempestdx/sdk-go v0.1.5
 	github.com/tidwall/pretty v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	github.com/tempestdx/openapi v0.1.4
+	github.com/tempestdx/openapi v0.1.5
 	github.com/tempestdx/protobuf v0.1.3
 	github.com/tempestdx/sdk-go v0.1.5
 	github.com/tidwall/pretty v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	github.com/tempestdx/openapi v0.1.4-0.20250212133319-e88281891713
+	github.com/tempestdx/openapi v0.1.4-0.20250214031059-8fe414f76597
 	github.com/tempestdx/protobuf v0.1.3
 	github.com/tempestdx/sdk-go v0.1.5
 	github.com/tidwall/pretty v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	github.com/tempestdx/openapi v0.1.3
+	github.com/tempestdx/openapi v0.1.4-0.20250212133319-e88281891713
 	github.com/tempestdx/protobuf v0.1.3
 	github.com/tempestdx/sdk-go v0.1.5
 	github.com/tidwall/pretty v1.2.1
@@ -30,7 +30,7 @@ require (
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
-	github.com/go-chi/chi/v5 v5.2.0 // indirect
+	github.com/go-chi/chi/v5 v5.2.1 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tempestdx/openapi v0.1.4 h1:r+JCt4Ud3e51zyut9jKdgKx3M3BvSie1ZLUgEpGQuto=
-github.com/tempestdx/openapi v0.1.4/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
+github.com/tempestdx/openapi v0.1.5 h1:T31Fiwzbe4GshR76Lc99lzUjZBymG71nSj+aogmV7lA=
+github.com/tempestdx/openapi v0.1.5/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
 github.com/tempestdx/protobuf v0.1.3 h1:FdHLe8asp9NrhZcI6JLtwPyHCuOPfio6bdbh8fFGD/k=
 github.com/tempestdx/protobuf v0.1.3/go.mod h1:zg0gZj3E9JVY5z8ooc/pOXH9AeClM4Gl9+ehvYsB5Qg=
 github.com/tempestdx/sdk-go v0.1.5 h1:elxDHwnz8+Rku8yL+nBRUEsa1e6KdlT8mIsfx7+7LBA=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/charmbracelet/x/ansi v0.1.4 h1:IEU3D6+dWwPSgZ6HBH+v6oUuZ/nVawMiWj5831
 github.com/charmbracelet/x/ansi v0.1.4/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240715153702-9ba8adf781c4 h1:6KzMkQeAF56rggw2NZu1L+TH7j9+DM1/2Kmh7KUxg1I=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240715153702-9ba8adf781c4/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
-github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
 github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
@@ -92,10 +92,10 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tempestdx/openapi v0.1.4-0.20250214031059-8fe414f76597 h1:gCpPzB1SsuicyROHjNm+KeA/f6vyslGX8/vi/YY+7ys=
-github.com/tempestdx/openapi v0.1.4-0.20250214031059-8fe414f76597/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
+github.com/tempestdx/openapi v0.1.4 h1:r+JCt4Ud3e51zyut9jKdgKx3M3BvSie1ZLUgEpGQuto=
+github.com/tempestdx/openapi v0.1.4/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
 github.com/tempestdx/protobuf v0.1.3 h1:FdHLe8asp9NrhZcI6JLtwPyHCuOPfio6bdbh8fFGD/k=
 github.com/tempestdx/protobuf v0.1.3/go.mod h1:zg0gZj3E9JVY5z8ooc/pOXH9AeClM4Gl9+ehvYsB5Qg=
 github.com/tempestdx/sdk-go v0.1.5 h1:elxDHwnz8+Rku8yL+nBRUEsa1e6KdlT8mIsfx7+7LBA=

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tempestdx/openapi v0.1.4-0.20250212133319-e88281891713 h1:km2yK4jviCGbwyVOillKUPw910EhTp5EiLH9CMtAQ78=
-github.com/tempestdx/openapi v0.1.4-0.20250212133319-e88281891713/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
+github.com/tempestdx/openapi v0.1.4-0.20250214031059-8fe414f76597 h1:gCpPzB1SsuicyROHjNm+KeA/f6vyslGX8/vi/YY+7ys=
+github.com/tempestdx/openapi v0.1.4-0.20250214031059-8fe414f76597/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
 github.com/tempestdx/protobuf v0.1.3 h1:FdHLe8asp9NrhZcI6JLtwPyHCuOPfio6bdbh8fFGD/k=
 github.com/tempestdx/protobuf v0.1.3/go.mod h1:zg0gZj3E9JVY5z8ooc/pOXH9AeClM4Gl9+ehvYsB5Qg=
 github.com/tempestdx/sdk-go v0.1.5 h1:elxDHwnz8+Rku8yL+nBRUEsa1e6KdlT8mIsfx7+7LBA=

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/go-chi/chi/v5 v5.2.0 h1:Aj1EtB0qR2Rdo2dG4O94RIU35w2lvQSj6BRA4+qwFL0=
-github.com/go-chi/chi/v5 v5.2.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -103,8 +103,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tempestdx/openapi v0.1.3 h1:Q12FO00IbmIlhB6qIrf9A1qf56s5e7hRGo1yfD55XQ0=
-github.com/tempestdx/openapi v0.1.3/go.mod h1:178IJqKf1lJUOXKlcHtv5Xmt8HLUCW/rUVVHJOUE2FA=
+github.com/tempestdx/openapi v0.1.4-0.20250212133319-e88281891713 h1:km2yK4jviCGbwyVOillKUPw910EhTp5EiLH9CMtAQ78=
+github.com/tempestdx/openapi v0.1.4-0.20250212133319-e88281891713/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
 github.com/tempestdx/protobuf v0.1.3 h1:FdHLe8asp9NrhZcI6JLtwPyHCuOPfio6bdbh8fFGD/k=
 github.com/tempestdx/protobuf v0.1.3/go.mod h1:zg0gZj3E9JVY5z8ooc/pOXH9AeClM4Gl9+ehvYsB5Qg=
 github.com/tempestdx/sdk-go v0.1.5 h1:elxDHwnz8+Rku8yL+nBRUEsa1e6KdlT8mIsfx7+7LBA=


### PR DESCRIPTION
### Added new CLI commands for managing projects, recipes, and resources

Added commands to list and get details for core Tempest entities:
- `tempest project list/get` - Manage projects
- `tempest recipe list/get` - Manage recipes
- `tempest resource list/get` - Manage resources

All list commands support `--limit` flags to limit output. 
- `tempest project list [--limit n]`
- `tempest recipe list [--limit n]`
- `tempest resource list [--limit n]`
