### PR TITLE
Fix singular form, small refactor, adds tests

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -127,7 +127,7 @@ func listProjects(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	cmd.Printf("%s\n", messages.FormatShowingSummary(len(allProjects), totalFetched, "project", limitFlag > 0))
+	cmd.Printf("%s\n", messages.FormatShowingSummary(len(allProjects), totalFetched, "project"))
 
 	return nil
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -129,7 +129,7 @@ func listProjects(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	cmd.Print(messages.FormatShowingSummary(len(allProjects), totalFetched, pageCount, "project", limitFlag > 0))
+	cmd.Printf("%s\n", messages.FormatShowingSummary(len(allProjects), totalFetched, pageCount, "project", limitFlag > 0))
 
 	return nil
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -1,0 +1,288 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/spf13/cobra"
+	"github.com/tempestdx/cli/internal/secret"
+	appapi "github.com/tempestdx/openapi/app"
+)
+
+var projectCmd = &cobra.Command{
+	Use:   "project",
+	Short: "Manage projects",
+	Long:  `List and get projects from your Tempest App`,
+}
+
+var projectListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all projects",
+	Args:  cobra.NoArgs,
+	RunE:  listProjects,
+}
+
+var projectGetCmd = &cobra.Command{
+	Use:   "get <project_id>",
+	Short: "Get a specific project",
+	Args:  cobra.ExactArgs(1),
+	RunE:  getProject,
+}
+
+func init() {
+	rootCmd.AddCommand(projectCmd)
+	projectCmd.AddCommand(projectListCmd)
+	projectCmd.AddCommand(projectGetCmd)
+
+	projectListCmd.Flags().IntVar(&limitFlag, "limit", 0, "Limit the number of projects shown")
+}
+
+func listProjects(cmd *cobra.Command, args []string) error {
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	var allProjects []appapi.Project
+	var nextToken *string
+	pageCount := 0
+
+	for {
+		pageCount++
+		res, err := tempestClient.PostProjectsListWithResponse(context.TODO(), appapi.PostProjectsListJSONRequestBody{
+			Next: nextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("list projects: %w", err)
+		}
+
+		if res.JSON200 == nil {
+			if res.JSON400 != nil {
+				return fmt.Errorf("bad request: %s", res.JSON400.Error)
+			}
+			if res.JSON500 != nil {
+				return fmt.Errorf("server error: %s", res.JSON500.Error)
+			}
+			return fmt.Errorf("unexpected response: %s", res.Status())
+		}
+
+		allProjects = append(allProjects, res.JSON200.Projects...)
+
+		if res.JSON200.Next == "" {
+			break
+		}
+		nextToken = &res.JSON200.Next
+	}
+
+	totalFetched := len(allProjects)
+
+	if limitFlag > 0 && len(allProjects) > limitFlag {
+		allProjects = allProjects[:limitFlag]
+	}
+
+	table := "| ID | Name | Type | From Recipe | Organization ID | Team ID |\n"
+	table += "|----|------|------|-------------|-----------------|----------|\n"
+
+	for _, project := range allProjects {
+		var fromRecipe string
+		if project.FromRecipe != nil {
+			fromRecipe = *project.FromRecipe
+		}
+		var teamID string
+		if project.TeamId != nil {
+			teamID = *project.TeamId
+		}
+		table += fmt.Sprintf("| %s | %s | %s | %s | %s | %s |\n",
+			project.Id,
+			project.Name,
+			project.Type,
+			fromRecipe,
+			project.OrganizationId,
+			teamID,
+		)
+	}
+
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(120),
+	)
+	if err != nil {
+		return fmt.Errorf("create renderer: %w", err)
+	}
+
+	out, err := renderer.Render(table)
+	if err != nil {
+		return fmt.Errorf("render table: %w", err)
+	}
+	cmd.Print(out)
+
+	if limitFlag > 0 {
+		cmd.Printf("Showing %d/%d projects\n", len(allProjects), totalFetched)
+	} else {
+		cmd.Printf("Showing %d projects from %d pages\n", len(allProjects), pageCount)
+	}
+
+	return nil
+}
+
+func getProject(cmd *cobra.Command, args []string) error {
+	projectID := args[0]
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	res, err := tempestClient.PostProjectsGetWithResponse(context.TODO(), appapi.PostProjectsGetJSONRequestBody{
+		Id: projectID,
+	})
+	if err != nil {
+		return fmt.Errorf("get project: %w", err)
+	}
+
+	if res.JSON200 == nil {
+		if res.JSON400 != nil {
+			return fmt.Errorf("bad request: %s", res.JSON400.Error)
+		}
+		if res.JSON404 != nil {
+			return fmt.Errorf("not found: %s", res.JSON404.Error)
+		}
+		if res.JSON500 != nil {
+			return fmt.Errorf("server error: %s", res.JSON500.Error)
+		}
+		return fmt.Errorf("unexpected response: %s", res.Status())
+	}
+
+	project := res.JSON200
+
+	// Main Information
+	mainInfo := map[string]string{
+		"Name": project.Name,
+		"ID":   project.Id,
+	}
+
+	// Extract and sort keys
+	mainInfoKeys := make([]string, 0, len(mainInfo))
+	for key := range mainInfo {
+		mainInfoKeys = append(mainInfoKeys, key)
+	}
+	sort.Strings(mainInfoKeys)
+
+	// Calculate the maximum key length for main information
+	maxMainInfoKeyLength := 0
+	for _, key := range mainInfoKeys {
+		if len(key) > maxMainInfoKeyLength {
+			maxMainInfoKeyLength = len(key)
+		}
+	}
+
+	// Print each main information with aligned keys
+	for _, key := range mainInfoKeys {
+		value := mainInfo[key]
+		cmd.Printf("%-*s : %s\n", maxMainInfoKeyLength, key, value)
+	}
+	cmd.Println()
+
+	// Metadata
+	cmd.Println("Metadata:")
+	teamID := "-"
+	if project.TeamId != nil {
+		teamID = *project.TeamId
+	}
+	createdAt := "-"
+	if project.CreatedAt != nil {
+		createdAt = project.CreatedAt.Format(time.RFC3339)
+	}
+	updatedAt := "-"
+	if project.UpdatedAt != nil {
+		updatedAt = project.UpdatedAt.Format(time.RFC3339)
+	}
+
+	metadata := map[string]string{
+		"Type":               project.Type,
+		"Organization ID":    project.OrganizationId,
+		"Team ID":            teamID,
+		"Creation Timestamp": createdAt,
+		"Last Updated":       updatedAt,
+	}
+
+	// Extract and sort keys
+	metadataKeys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		metadataKeys = append(metadataKeys, key)
+	}
+	sort.Strings(metadataKeys)
+
+	// Calculate the maximum key length for metadata
+	maxMetadataKeyLength := 0
+	for _, key := range metadataKeys {
+		if len(key) > maxMetadataKeyLength {
+			maxMetadataKeyLength = len(key)
+		}
+	}
+
+	// Print each metadata with aligned keys
+	for _, key := range metadataKeys {
+		value := metadata[key]
+		cmd.Printf("  %-*s : %s\n", maxMetadataKeyLength, key, value)
+	}
+	cmd.Println()
+
+	// Status
+	cmd.Println("Status:")
+	published := "-"
+	if project.Published != nil {
+		published = fmt.Sprintf("%v", *project.Published)
+	}
+	fromRecipe := "-"
+	if project.FromRecipe != nil {
+		fromRecipe = *project.FromRecipe
+	}
+
+	status := map[string]string{
+		"Published":   published,
+		"From Recipe": fromRecipe,
+	}
+
+	// Extract and sort keys
+	statusKeys := make([]string, 0, len(status))
+	for key := range status {
+		statusKeys = append(statusKeys, key)
+	}
+	sort.Strings(statusKeys)
+
+	// Calculate the maximum key length for status
+	maxStatusKeyLength := 0
+	for _, key := range statusKeys {
+		if len(key) > maxStatusKeyLength {
+			maxStatusKeyLength = len(key)
+		}
+	}
+
+	// Print each status with aligned keys
+	for _, key := range statusKeys {
+		value := status[key]
+		cmd.Printf("  %-*s : %s\n", maxStatusKeyLength, key, value)
+	}
+
+	return nil
+}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/glamour"
 	"github.com/spf13/cobra"
+	"github.com/tempestdx/cli/internal/messages"
 	"github.com/tempestdx/cli/internal/secret"
 	appapi "github.com/tempestdx/openapi/app"
 )
@@ -128,11 +129,7 @@ func listProjects(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	if limitFlag > 0 {
-		cmd.Printf("Showing %d/%d projects\n", len(allProjects), totalFetched)
-	} else {
-		cmd.Printf("Showing %d projects from %d pages\n", len(allProjects), pageCount)
-	}
+	cmd.Print(messages.FormatShowingSummary(len(allProjects), totalFetched, pageCount, "project", limitFlag > 0))
 
 	return nil
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -58,10 +58,8 @@ func listProjects(cmd *cobra.Command, args []string) error {
 
 	var allProjects []appapi.Project
 	var nextToken *string
-	pageCount := 0
 
 	for {
-		pageCount++
 		res, err := tempestClient.PostProjectsListWithResponse(context.TODO(), appapi.PostProjectsListJSONRequestBody{
 			Next: nextToken,
 		})
@@ -129,7 +127,7 @@ func listProjects(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	cmd.Printf("%s\n", messages.FormatShowingSummary(len(allProjects), totalFetched, pageCount, "project", limitFlag > 0))
+	cmd.Printf("%s\n", messages.FormatShowingSummary(len(allProjects), totalFetched, "project", limitFlag > 0))
 
 	return nil
 }

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -139,7 +139,7 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	cmd.Printf("%s\n", messages.FormatShowingSummary(len(recipes), totalFetched, "recipe", limitFlag > 0))
+	cmd.Printf("%s\n", messages.FormatShowingSummary(len(recipes), totalFetched, "recipe"))
 
 	return nil
 }

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -1,0 +1,302 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/spf13/cobra"
+	"github.com/tempestdx/cli/internal/secret"
+	appapi "github.com/tempestdx/openapi/app"
+)
+
+var recipeCmd = &cobra.Command{
+	Use:   "recipe",
+	Short: "Manage recipes",
+	Long:  `List and get recipes from your Tempest App`,
+}
+
+var recipeListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all recipes",
+	Args:  cobra.NoArgs,
+	RunE:  listRecipes,
+}
+
+var recipeGetCmd = &cobra.Command{
+	Use:   "get <recipe_id>",
+	Short: "Get a specific recipe",
+	Args:  cobra.ExactArgs(1),
+	RunE:  getRecipe,
+}
+
+func init() {
+	rootCmd.AddCommand(recipeCmd)
+	recipeCmd.AddCommand(recipeListCmd)
+	recipeCmd.AddCommand(recipeGetCmd)
+
+	recipeListCmd.Flags().IntVar(&limitFlag, "limit", 0, "Limit the number of recipes shown")
+}
+
+func listRecipes(cmd *cobra.Command, args []string) error {
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	var allRecipes []appapi.Recipe
+	var nextToken *string
+
+	for {
+		res, err := tempestClient.PostRecipesListWithResponse(context.TODO(), appapi.PostRecipesListJSONRequestBody{
+			Next: nextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("list recipes: %w", err)
+		}
+
+		if res.JSON200 == nil {
+			if res.JSON400 != nil {
+				return fmt.Errorf("bad request: %s", res.JSON400.Error)
+			}
+			if res.JSON500 != nil {
+				return fmt.Errorf("server error: %s", res.JSON500.Error)
+			}
+			return fmt.Errorf("unexpected response: %s", res.Status())
+		}
+
+		allRecipes = append(allRecipes, res.JSON200.Recipes...)
+
+		if res.JSON200.Next == "" {
+			break
+		}
+		nextToken = &res.JSON200.Next
+	}
+
+	totalFetched := len(allRecipes)
+
+	if limitFlag > 0 && len(allRecipes) > limitFlag {
+		allRecipes = allRecipes[:limitFlag]
+	}
+
+	recipes := allRecipes
+
+	table := "| ID | Name | Type | Team ID | Public | Published | Published At |\n"
+	table += "|-------|------|------|---------|---------|-----------|-------------|\n"
+
+	for _, recipe := range recipes {
+		var teamID string
+		if recipe.TeamId != nil {
+			teamID = *recipe.TeamId
+		}
+		var public string
+		if recipe.Public != nil {
+			public = fmt.Sprintf("%v", *recipe.Public)
+		}
+		var published string
+		if recipe.Published != nil {
+			published = fmt.Sprintf("%v", *recipe.Published)
+		}
+		var publishedAt string
+		if recipe.PublishedAt != nil {
+			publishedAt = recipe.PublishedAt.Format(time.RFC3339)
+		}
+
+		table += fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s |\n",
+			recipe.Id,
+			recipe.Name,
+			recipe.Type,
+			teamID,
+			public,
+			published,
+			publishedAt,
+		)
+	}
+
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(120),
+	)
+	if err != nil {
+		return fmt.Errorf("create renderer: %w", err)
+	}
+
+	out, err := renderer.Render(table)
+	if err != nil {
+		return fmt.Errorf("render table: %w", err)
+	}
+	cmd.Print(out)
+
+	if limitFlag > 0 {
+		cmd.Printf("Showing %d/%d recipes\n", len(recipes), totalFetched)
+	} else {
+		cmd.Printf("Showing %d recipes\n", len(recipes))
+	}
+
+	return nil
+}
+
+func getRecipe(cmd *cobra.Command, args []string) error {
+	recipeID := args[0]
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	res, err := tempestClient.PostRecipesGetWithResponse(context.TODO(), appapi.PostRecipesGetJSONRequestBody{
+		Id: recipeID,
+	})
+	if err != nil {
+		return fmt.Errorf("get recipe: %w", err)
+	}
+
+	if res.JSON200 == nil {
+		if res.JSON400 != nil {
+			return fmt.Errorf("bad request: %s", res.JSON400.Error)
+		}
+		if res.JSON404 != nil {
+			return fmt.Errorf("not found: %s", res.JSON404.Error)
+		}
+		if res.JSON500 != nil {
+			return fmt.Errorf("server error: %s", res.JSON500.Error)
+		}
+		return fmt.Errorf("unexpected response: %s", res.Status())
+	}
+
+	recipe := res.JSON200
+
+	// Main Information
+	mainInfo := map[string]string{
+		"Name": recipe.Name,
+		"ID":   recipe.Id,
+		"Type": recipe.Type,
+	}
+
+	// Extract and sort keys
+	mainInfoKeys := make([]string, 0, len(mainInfo))
+	for key := range mainInfo {
+		mainInfoKeys = append(mainInfoKeys, key)
+	}
+	sort.Strings(mainInfoKeys)
+
+	// Calculate the maximum key length for main information
+	maxMainInfoKeyLength := 0
+	for _, key := range mainInfoKeys {
+		if len(key) > maxMainInfoKeyLength {
+			maxMainInfoKeyLength = len(key)
+		}
+	}
+
+	// Print each main information with aligned keys
+	for _, key := range mainInfoKeys {
+		value := mainInfo[key]
+		cmd.Printf("%-*s : %s\n", maxMainInfoKeyLength, key, value)
+	}
+	cmd.Println()
+
+	// Metadata
+	cmd.Println("Metadata:")
+	teamID := "-"
+	if recipe.TeamId != nil {
+		teamID = *recipe.TeamId
+	}
+	createdAt := "-"
+	if recipe.CreatedAt != nil {
+		createdAt = recipe.CreatedAt.Format(time.RFC3339)
+	}
+	updatedAt := "-"
+	if recipe.UpdatedAt != nil {
+		updatedAt = recipe.UpdatedAt.Format(time.RFC3339)
+	}
+
+	metadata := map[string]string{
+		"Team ID":            teamID,
+		"Creation Timestamp": createdAt,
+		"Last Updated":       updatedAt,
+	}
+
+	// Extract and sort keys
+	keys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Calculate the maximum key length for metadata
+	maxMetadataKeyLength := 0
+	for _, key := range keys {
+		if len(key) > maxMetadataKeyLength {
+			maxMetadataKeyLength = len(key)
+		}
+	}
+
+	// Print each metadata with aligned keys
+	for _, key := range keys {
+		value := metadata[key]
+		cmd.Printf("  %-*s : %s\n", maxMetadataKeyLength, key, value)
+	}
+	cmd.Println()
+
+	// Status
+	cmd.Println("Status:")
+	public := "-"
+	if recipe.Public != nil {
+		public = fmt.Sprintf("%v", *recipe.Public)
+	}
+	published := "-"
+	if recipe.Published != nil {
+		published = fmt.Sprintf("%v", *recipe.Published)
+	}
+	publishedAt := "-"
+	if recipe.PublishedAt != nil {
+		publishedAt = recipe.PublishedAt.Format(time.RFC3339)
+	}
+
+	status := map[string]string{
+		"Public":       public,
+		"Published":    published,
+		"Published At": publishedAt,
+	}
+
+	// Extract and sort keys
+	statusKeys := make([]string, 0, len(status))
+	for key := range status {
+		statusKeys = append(statusKeys, key)
+	}
+	sort.Strings(statusKeys)
+
+	// Calculate the maximum key length for status
+	maxStatusKeyLength := 0
+	for _, key := range statusKeys {
+		if len(key) > maxStatusKeyLength {
+			maxStatusKeyLength = len(key)
+		}
+	}
+
+	// Print each status with aligned keys
+	for _, key := range statusKeys {
+		value := status[key]
+		cmd.Printf("  %-*s : %s\n", maxStatusKeyLength, key, value)
+	}
+
+	return nil
+}

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tempestdx/cli/internal/secret"
 	appapi "github.com/tempestdx/openapi/app"
+	"github.com/tempestdx/cli/internal/messages"
 )
 
 var recipeCmd = &cobra.Command{
@@ -57,8 +58,10 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 
 	var allRecipes []appapi.Recipe
 	var nextToken *string
+	pageCount := 0
 
 	for {
+		pageCount++
 		res, err := tempestClient.PostRecipesListWithResponse(context.TODO(), appapi.PostRecipesListJSONRequestBody{
 			Next: nextToken,
 		})
@@ -138,11 +141,7 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	if limitFlag > 0 {
-		cmd.Printf("Showing %d/%d recipes\n", len(recipes), totalFetched)
-	} else {
-		cmd.Printf("Showing %d recipes\n", len(recipes))
-	}
+	cmd.Print(messages.FormatShowingSummary(len(recipes), totalFetched, pageCount, "recipe", limitFlag > 0))
 
 	return nil
 }

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/charmbracelet/glamour"
 	"github.com/spf13/cobra"
+	"github.com/tempestdx/cli/internal/messages"
 	"github.com/tempestdx/cli/internal/secret"
 	appapi "github.com/tempestdx/openapi/app"
-	"github.com/tempestdx/cli/internal/messages"
 )
 
 var recipeCmd = &cobra.Command{
@@ -141,7 +141,7 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	cmd.Print(messages.FormatShowingSummary(len(recipes), totalFetched, pageCount, "recipe", limitFlag > 0))
+	cmd.Printf("%s\n", messages.FormatShowingSummary(len(recipes), totalFetched, pageCount, "recipe", limitFlag > 0))
 
 	return nil
 }

--- a/cmd/recipe.go
+++ b/cmd/recipe.go
@@ -58,10 +58,8 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 
 	var allRecipes []appapi.Recipe
 	var nextToken *string
-	pageCount := 0
 
 	for {
-		pageCount++
 		res, err := tempestClient.PostRecipesListWithResponse(context.TODO(), appapi.PostRecipesListJSONRequestBody{
 			Next: nextToken,
 		})
@@ -141,7 +139,7 @@ func listRecipes(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	cmd.Printf("%s\n", messages.FormatShowingSummary(len(recipes), totalFetched, pageCount, "recipe", limitFlag > 0))
+	cmd.Printf("%s\n", messages.FormatShowingSummary(len(recipes), totalFetched, "recipe", limitFlag > 0))
 
 	return nil
 }

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -130,7 +130,7 @@ func listResources(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	cmd.Printf("%s\n", messages.FormatShowingSummary(len(resources), totalFetched, "resource", limitFlag > 0))
+	cmd.Printf("%s\n", messages.FormatShowingSummary(len(resources), totalFetched, "resource"))
 
 	return nil
 }

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -132,7 +132,7 @@ func listResources(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	cmd.Print(messages.FormatShowingSummary(len(resources), totalFetched, pageCount, "resource", limitFlag > 0))
+	cmd.Printf("%s\n", messages.FormatShowingSummary(len(resources), totalFetched, pageCount, "resource", limitFlag > 0))
 
 	return nil
 }

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -1,0 +1,306 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/spf13/cobra"
+	"github.com/tempestdx/cli/internal/secret"
+	appapi "github.com/tempestdx/openapi/app"
+)
+
+var resourceCmd = &cobra.Command{
+	Use:   "resource",
+	Short: "Manage resources",
+	Long:  `List and get resources from your Tempest App`,
+}
+
+var resourceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all resources",
+	Args:  cobra.NoArgs,
+	RunE:  listResources,
+}
+
+var resourceGetCmd = &cobra.Command{
+	Use:   "get <resource_id>",
+	Short: "Get a specific resource",
+	Args:  cobra.ExactArgs(1),
+	RunE:  getResource,
+}
+
+func init() {
+	rootCmd.AddCommand(resourceCmd)
+	resourceCmd.AddCommand(resourceListCmd)
+	resourceCmd.AddCommand(resourceGetCmd)
+
+	resourceListCmd.Flags().IntVar(&limitFlag, "limit", 0, "Limit the number of resources shown")
+}
+
+func listResources(cmd *cobra.Command, args []string) error {
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	var allResources []appapi.Resource
+	var nextToken *string
+
+	for {
+		res, err := tempestClient.PostResourcesListWithResponse(context.TODO(), appapi.PostResourcesListJSONRequestBody{
+			Next: nextToken,
+		})
+		if err != nil {
+			return fmt.Errorf("list resources: %w", err)
+		}
+
+		if res.JSON200 == nil {
+			if res.JSON400 != nil {
+				return fmt.Errorf("bad request: %s", res.JSON400.Error)
+			}
+			if res.JSON500 != nil {
+				return fmt.Errorf("server error: %s", res.JSON500.Error)
+			}
+			return fmt.Errorf("unexpected response: %s", res.Status())
+		}
+
+		allResources = append(allResources, res.JSON200.Resources...)
+
+		if res.JSON200.Next == "" {
+			break
+		}
+		nextToken = &res.JSON200.Next
+	}
+
+	totalFetched := len(allResources)
+
+	if limitFlag > 0 && len(allResources) > limitFlag {
+		allResources = allResources[:limitFlag]
+	}
+
+	resources := allResources
+
+	table := "| ID | Name | Type | Organization ID |\n"
+	table += "|-------|------|------|----------------|\n"
+
+	for _, resource := range resources {
+		var name string
+		if resource.Name != nil {
+			name = *resource.Name
+		}
+		var orgID string
+		if resource.OrganizationId != nil {
+			orgID = *resource.OrganizationId
+		}
+
+		table += fmt.Sprintf("| %s | %s | %s | %s |\n",
+			*resource.Id,
+			name,
+			resource.Type,
+			orgID,
+		)
+	}
+
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(120),
+	)
+	if err != nil {
+		return fmt.Errorf("create renderer: %w", err)
+	}
+
+	out, err := renderer.Render(table)
+	if err != nil {
+		return fmt.Errorf("render table: %w", err)
+	}
+	cmd.Print(out)
+
+	if limitFlag > 0 {
+		cmd.Printf("Showing %d/%d resources\n", len(resources), totalFetched)
+	} else {
+		cmd.Printf("Showing %d resources\n", len(resources))
+	}
+
+	return nil
+}
+
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
+func getResource(cmd *cobra.Command, args []string) error {
+	resourceID := args[0]
+	token := loadTempestToken(cmd)
+
+	tempestClient, err := appapi.NewClientWithResponses(
+		apiEndpoint,
+		appapi.WithHTTPClient(&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: secret.NewTransportWithToken(token),
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	body := appapi.PostResourcesGetJSONRequestBody{Id: resourceID}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal request body: %w", err)
+	}
+
+	res, err := tempestClient.PostResourcesGetWithBodyWithResponse(context.TODO(), "POST", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("get resource: %w", err)
+	}
+
+	if res.JSON200 == nil {
+		if res.JSON400 != nil {
+			return fmt.Errorf("bad request: %s", res.JSON400.Error)
+		}
+		if res.JSON404 != nil {
+			return fmt.Errorf("not found: %s", res.JSON404.Error)
+		}
+		if res.JSON500 != nil {
+			return fmt.Errorf("server error: %s", res.JSON500.Error)
+		}
+		return fmt.Errorf("unexpected response: %s", res.Status())
+	}
+
+	resource := res.JSON200
+	name := "-"
+	if resource.Name != nil {
+		name = *resource.Name
+	}
+
+	orgID := "-"
+	if resource.OrganizationId != nil {
+		orgID = *resource.OrganizationId
+	}
+
+	createdBy := "-"
+	if resource.CreatedBy != nil {
+		createdBy = *resource.CreatedBy
+	}
+
+	createdAt := "-"
+	if resource.CreatedAt != nil {
+		createdAt = resource.CreatedAt.Format(time.RFC3339)
+	}
+
+	updatedAt := "-"
+	if resource.UpdatedAt != nil {
+		updatedAt = resource.UpdatedAt.Format(time.RFC3339)
+	}
+
+	syncedAt := "-"
+	if resource.SyncedAt != nil {
+		syncedAt = resource.SyncedAt.Format(time.RFC3339)
+	}
+
+	externalID := "-"
+	if resource.ExternalId != "" {
+		externalID = resource.ExternalId
+	}
+
+	externalURL := "-"
+	if resource.ExternalUrl != nil && len(*resource.ExternalUrl) > 0 {
+		externalURL = *resource.ExternalUrl
+	}
+
+	// Define the fields for the initial section using KeyValue slice
+	initialFields := []KeyValue{
+		{"Name", name},
+		{"ID", *resource.Id},
+		{"External ID", externalID},
+		{"External URL", externalURL},
+	}
+
+	// Calculate the maximum key length for the initial fields
+	maxInitialKeyLength := 0
+	for _, kv := range initialFields {
+		if len(kv.Key) > maxInitialKeyLength {
+			maxInitialKeyLength = len(kv.Key)
+		}
+	}
+
+	// Print each initial field with aligned keys
+	for _, kv := range initialFields {
+		cmd.Printf("%-*s : %-30s\n", maxInitialKeyLength, kv.Key, kv.Value)
+	}
+	cmd.Println()
+
+	cmd.Println("Metadata:")
+	metadata := []KeyValue{
+		{"Type", resource.Type},
+		{"Organization ID", orgID},
+		{"Created By", createdBy},
+		{"Creation Timestamp", createdAt},
+		{"Last Updated", updatedAt},
+		{"Last Synced", syncedAt},
+	}
+
+	// Calculate the maximum key length for metadata
+	maxMetadataKeyLength := 0
+	for _, kv := range metadata {
+		if len(kv.Key) > maxMetadataKeyLength {
+			maxMetadataKeyLength = len(kv.Key)
+		}
+	}
+
+	// Print each metadata with aligned keys
+	for _, kv := range metadata {
+		cmd.Printf("  %-*s : %-30s\n", maxMetadataKeyLength, kv.Key, kv.Value)
+	}
+	cmd.Println()
+
+	cmd.Println("Properties:")
+	if resource.Properties != nil && len(*resource.Properties) > 0 {
+		// Extract and sort keys
+		keys := make([]string, 0, len(*resource.Properties))
+		for key := range *resource.Properties {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		// Calculate the maximum key length for properties
+		maxPropertyKeyLength := 0
+		for _, key := range keys {
+			if len(key) > maxPropertyKeyLength {
+				maxPropertyKeyLength = len(key)
+			}
+		}
+
+		// Print each property with aligned keys
+		for _, key := range keys {
+			value := (*resource.Properties)[key]
+			cmd.Printf("  %-*s : %-30v\n", maxPropertyKeyLength, key, value)
+		}
+	} else {
+		cmd.Printf("  -\n")
+	}
+	cmd.Println()
+
+	status := "-"
+	if resource.Status != nil {
+		status = *resource.Status
+	}
+	cmd.Printf("%-*s: %-30s\n", len("Status"), "Status", status)
+
+	return nil
+}

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/charmbracelet/glamour"
 	"github.com/spf13/cobra"
+	"github.com/tempestdx/cli/internal/messages"
 	"github.com/tempestdx/cli/internal/secret"
 	appapi "github.com/tempestdx/openapi/app"
 )
@@ -59,8 +60,10 @@ func listResources(cmd *cobra.Command, args []string) error {
 
 	var allResources []appapi.Resource
 	var nextToken *string
+	pageCount := 0
 
 	for {
+		pageCount++
 		res, err := tempestClient.PostResourcesListWithResponse(context.TODO(), appapi.PostResourcesListJSONRequestBody{
 			Next: nextToken,
 		})
@@ -129,11 +132,7 @@ func listResources(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	if limitFlag > 0 {
-		cmd.Printf("Showing %d/%d resources\n", len(resources), totalFetched)
-	} else {
-		cmd.Printf("Showing %d resources\n", len(resources))
-	}
+	cmd.Print(messages.FormatShowingSummary(len(resources), totalFetched, pageCount, "resource", limitFlag > 0))
 
 	return nil
 }

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -60,10 +60,8 @@ func listResources(cmd *cobra.Command, args []string) error {
 
 	var allResources []appapi.Resource
 	var nextToken *string
-	pageCount := 0
 
 	for {
-		pageCount++
 		res, err := tempestClient.PostResourcesListWithResponse(context.TODO(), appapi.PostResourcesListJSONRequestBody{
 			Next: nextToken,
 		})
@@ -132,7 +130,7 @@ func listResources(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Print(out)
 
-	cmd.Printf("%s\n", messages.FormatShowingSummary(len(resources), totalFetched, pageCount, "resource", limitFlag > 0))
+	cmd.Printf("%s\n", messages.FormatShowingSummary(len(resources), totalFetched, "resource", limitFlag > 0))
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,9 @@ var (
 	tokenStore  secret.TokenStore
 	debugMode   bool
 
+	limitFlag int
+
+
 	rootCmd = &cobra.Command{
 		Use:     "tempest [command] [flags]",
 		Short:   "Tempest is a CLI tool to interact with the Tempest API and SDK",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/glamour v0.8.0
-	github.com/spf13/cobra v1.8.1
+	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tempestdx/openapi v0.1.3
 	github.com/tempestdx/protobuf v0.1.3
@@ -26,7 +26,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/lipgloss v0.12.1 // indirect
 	github.com/charmbracelet/x/ansi v0.1.4 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
@@ -48,7 +48,7 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/yuin/goldmark v1.7.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/glamour v0.8.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tempestdx/openapi v0.1.5

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	github.com/tempestdx/openapi v0.1.3
+	github.com/tempestdx/openapi v0.1.4
 	github.com/tempestdx/protobuf v0.1.3
 	github.com/tempestdx/sdk-go v0.1.5
 	github.com/tidwall/pretty v1.2.1
@@ -30,7 +30,7 @@ require (
 	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
-	github.com/go-chi/chi/v5 v5.2.0 // indirect
+	github.com/go-chi/chi/v5 v5.2.1 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	github.com/tempestdx/openapi v0.1.4
+	github.com/tempestdx/openapi v0.1.5
 	github.com/tempestdx/protobuf v0.1.3
 	github.com/tempestdx/sdk-go v0.1.5
 	github.com/tidwall/pretty v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tempestdx/openapi v0.1.4 h1:r+JCt4Ud3e51zyut9jKdgKx3M3BvSie1ZLUgEpGQuto=
-github.com/tempestdx/openapi v0.1.4/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
+github.com/tempestdx/openapi v0.1.5 h1:T31Fiwzbe4GshR76Lc99lzUjZBymG71nSj+aogmV7lA=
+github.com/tempestdx/openapi v0.1.5/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
 github.com/tempestdx/protobuf v0.1.3 h1:FdHLe8asp9NrhZcI6JLtwPyHCuOPfio6bdbh8fFGD/k=
 github.com/tempestdx/protobuf v0.1.3/go.mod h1:zg0gZj3E9JVY5z8ooc/pOXH9AeClM4Gl9+ehvYsB5Qg=
 github.com/tempestdx/sdk-go v0.1.5 h1:elxDHwnz8+Rku8yL+nBRUEsa1e6KdlT8mIsfx7+7LBA=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/charmbracelet/x/ansi v0.1.4 h1:IEU3D6+dWwPSgZ6HBH+v6oUuZ/nVawMiWj5831
 github.com/charmbracelet/x/ansi v0.1.4/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240715153702-9ba8adf781c4 h1:6KzMkQeAF56rggw2NZu1L+TH7j9+DM1/2Kmh7KUxg1I=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240715153702-9ba8adf781c4/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
-github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
 github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
@@ -92,10 +92,10 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/go-chi/chi/v5 v5.2.0 h1:Aj1EtB0qR2Rdo2dG4O94RIU35w2lvQSj6BRA4+qwFL0=
-github.com/go-chi/chi/v5 v5.2.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -103,8 +103,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tempestdx/openapi v0.1.3 h1:Q12FO00IbmIlhB6qIrf9A1qf56s5e7hRGo1yfD55XQ0=
-github.com/tempestdx/openapi v0.1.3/go.mod h1:178IJqKf1lJUOXKlcHtv5Xmt8HLUCW/rUVVHJOUE2FA=
+github.com/tempestdx/openapi v0.1.4 h1:r+JCt4Ud3e51zyut9jKdgKx3M3BvSie1ZLUgEpGQuto=
+github.com/tempestdx/openapi v0.1.4/go.mod h1:3AdW0ef0KQirQp/66/G+AP38M3uE0F4wK7drHe7Uk7s=
 github.com/tempestdx/protobuf v0.1.3 h1:FdHLe8asp9NrhZcI6JLtwPyHCuOPfio6bdbh8fFGD/k=
 github.com/tempestdx/protobuf v0.1.3/go.mod h1:zg0gZj3E9JVY5z8ooc/pOXH9AeClM4Gl9+ehvYsB5Qg=
 github.com/tempestdx/sdk-go v0.1.5 h1:elxDHwnz8+Rku8yL+nBRUEsa1e6KdlT8mIsfx7+7LBA=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=

--- a/internal/messages/utils.go
+++ b/internal/messages/utils.go
@@ -8,11 +8,9 @@ import (
 // FormatShowingSummary returns a formatted summary string for showing items
 // If limitFlag > 0, returns "Showing X/Y items"
 // Otherwise returns "Showing X items from Y pages"
-func FormatShowingSummary(itemCount, totalFetched, pageCount int, itemType string, hasLimit bool) string {
+func FormatShowingSummary(itemCount, totalFetched int, itemType string, hasLimit bool) string {
 	if hasLimit {
 		return fmt.Sprintf("Showing %d/%d %s", itemCount, totalFetched, english.PluralWord(itemCount, itemType, ""))
 	}
-	return fmt.Sprintf("Showing %d %s from %d %s",
-		itemCount, english.PluralWord(itemCount, itemType, ""),
-		pageCount, english.PluralWord(pageCount, "page", ""))
+	return fmt.Sprintf("Showing %d %s", itemCount, english.PluralWord(itemCount, itemType, ""))
 }

--- a/internal/messages/utils.go
+++ b/internal/messages/utils.go
@@ -1,0 +1,36 @@
+package messages
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatShowingSummary returns a formatted summary string for showing items
+// If limitFlag > 0, returns "Showing X/Y items"
+// Otherwise returns "Showing X items from Y pages"
+func FormatShowingSummary(itemCount, totalFetched, pageCount int, itemType string, hasLimit bool) string {
+	if hasLimit {
+		return fmt.Sprintf("Showing %d/%d %s", itemCount, totalFetched, pluralize(itemType, itemCount))
+	}
+	return fmt.Sprintf("Showing %d %s from %d %s",
+		itemCount, pluralize(itemType, itemCount),
+		pageCount, pluralize("page", pageCount))
+}
+
+// Pluralize returns the plural form of a word based on count.
+// For count == 1, returns the original word.
+// For count != 1, adds 's' or 'es' depending on the word ending.
+func pluralize(word string, count int) string {
+	if count == 1 {
+		return word
+	}
+	suffixes := []string{"s", "sh", "ch", "x", "z"}
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(word, suffix) {
+			return word + "es"
+		}
+	}
+
+	return word + "s"
+}
+

--- a/internal/messages/utils.go
+++ b/internal/messages/utils.go
@@ -8,8 +8,8 @@ import (
 // FormatShowingSummary returns a formatted summary string for showing items
 // If limitFlag > 0, returns "Showing X/Y items"
 // Otherwise returns "Showing X items from Y pages"
-func FormatShowingSummary(itemCount, totalFetched int, itemType string, hasLimit bool) string {
-	if hasLimit {
+func FormatShowingSummary(itemCount, totalFetched int, itemType string) string {
+	if itemCount != totalFetched {
 		return fmt.Sprintf("Showing %d/%d %s", itemCount, totalFetched, english.PluralWord(itemCount, itemType, ""))
 	}
 	return fmt.Sprintf("Showing %d %s", itemCount, english.PluralWord(itemCount, itemType, ""))

--- a/internal/messages/utils.go
+++ b/internal/messages/utils.go
@@ -2,7 +2,7 @@ package messages
 
 import (
 	"fmt"
-	"strings"
+	"github.com/dustin/go-humanize/english"
 )
 
 // FormatShowingSummary returns a formatted summary string for showing items
@@ -10,27 +10,9 @@ import (
 // Otherwise returns "Showing X items from Y pages"
 func FormatShowingSummary(itemCount, totalFetched, pageCount int, itemType string, hasLimit bool) string {
 	if hasLimit {
-		return fmt.Sprintf("Showing %d/%d %s", itemCount, totalFetched, pluralize(itemType, itemCount))
+		return fmt.Sprintf("Showing %d/%d %s", itemCount, totalFetched, english.PluralWord(itemCount, itemType, ""))
 	}
 	return fmt.Sprintf("Showing %d %s from %d %s",
-		itemCount, pluralize(itemType, itemCount),
-		pageCount, pluralize("page", pageCount))
+		itemCount, english.PluralWord(itemCount, itemType, ""),
+		pageCount, english.PluralWord(pageCount, "page", ""))
 }
-
-// Pluralize returns the plural form of a word based on count.
-// For count == 1, returns the original word.
-// For count != 1, adds 's' or 'es' depending on the word ending.
-func pluralize(word string, count int) string {
-	if count == 1 {
-		return word
-	}
-	suffixes := []string{"s", "sh", "ch", "x", "z"}
-	for _, suffix := range suffixes {
-		if strings.HasSuffix(word, suffix) {
-			return word + "es"
-		}
-	}
-
-	return word + "s"
-}
-

--- a/internal/messages/utils_test.go
+++ b/internal/messages/utils_test.go
@@ -75,22 +75,22 @@ func TestFormatShowingSummary(t *testing.T) {
 		expected     string
 	}{
 		{
-			name:         "no limit, no pages",
+			name:         "no limit, single page",
 			itemCount:    10,
 			totalFetched: 10,
 			pageCount:    1,
 			itemType:     "recipe",
 			hasLimit:     false,
-			expected:     "Showing 10 recipes",
+			expected:     "Showing 10 recipes from 1 page",
 		},
 		{
-			name:         "limit, no pages",
-			itemCount:    10,
+			name:         "limit, single form",
+			itemCount:    1,
 			totalFetched: 10,
 			pageCount:    1,
 			itemType:     "recipe",
 			hasLimit:     true,
-			expected:     "Showing 10/10 recipes",
+			expected:     "Showing 1/10 recipe",
 		},
 		{
 			name:         "no limit, multiple pages",
@@ -102,22 +102,13 @@ func TestFormatShowingSummary(t *testing.T) {
 			expected:     "Showing 10 recipes from 2 pages",
 		},
 		{
-			name:         "limit, multiple pages",
+			name:         "limit, plural form",
 			itemCount:    10,
 			totalFetched: 20,
 			pageCount:    2,
 			itemType:     "recipe",
 			hasLimit:     true,
 			expected:     "Showing 10/20 recipes",
-		},
-		{
-			name:         "no limit, multiple pages",
-			itemCount:    10,
-			totalFetched: 20,
-			pageCount:    2,
-			itemType:     "recipe",
-			hasLimit:     false,
-			expected:     "Showing 10 recipes from 2 pages",
 		},
 	}
 

--- a/internal/messages/utils_test.go
+++ b/internal/messages/utils_test.go
@@ -1,0 +1,133 @@
+package messages
+
+import "testing"
+
+func TestPluralize(t *testing.T) {
+	tests := []struct {
+		name     string
+		word     string
+		count    int
+		expected string
+	}{
+		{
+			name:     "singular cloud returns original word",
+			word:     "cloud",
+			count:    1,
+			expected: "cloud",
+		},
+		{
+			name:     "regular plural adds s",
+			word:     "cloud",
+			count:    2,
+			expected: "clouds",
+		},
+		{
+			name:     "word ending in sh adds es",
+			word:     "flash",
+			count:    3,
+			expected: "flashes",
+		},
+		{
+			name:     "word ending in ch adds es",
+			word:     "torch",
+			count:    0,
+			expected: "torches",
+		},
+		{
+			name:     "word ending in s adds es",
+			word:     "thunderstress",
+			count:    2,
+			expected: "thunderstresses",
+		},
+		{
+			name:     "word ending in x adds es",
+			word:     "vortex",
+			count:    4,
+			expected: "vortexes",
+		},
+		{
+			name:     "word ending in z adds es",
+			word:     "breeze",
+			count:    5,
+			expected: "breezes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pluralize(tt.word, tt.count)
+			if got != tt.expected {
+				t.Errorf("Pluralize(%q, %d) = %q, want %q",
+					tt.word, tt.count, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatShowingSummary(t *testing.T) {
+	tests := []struct {
+		name         string
+		itemCount    int
+		totalFetched int
+		pageCount    int
+		itemType     string
+		hasLimit     bool
+		expected     string
+	}{
+		{
+			name:         "no limit, no pages",
+			itemCount:    10,
+			totalFetched: 10,
+			pageCount:    1,
+			itemType:     "recipe",
+			hasLimit:     false,
+			expected:     "Showing 10 recipes",
+		},
+		{
+			name:         "limit, no pages",
+			itemCount:    10,
+			totalFetched: 10,
+			pageCount:    1,
+			itemType:     "recipe",
+			hasLimit:     true,
+			expected:     "Showing 10/10 recipes",
+		},
+		{
+			name:         "no limit, multiple pages",
+			itemCount:    10,
+			totalFetched: 20,
+			pageCount:    2,
+			itemType:     "recipe",
+			hasLimit:     false,
+			expected:     "Showing 10 recipes from 2 pages",
+		},
+		{
+			name:         "limit, multiple pages",
+			itemCount:    10,
+			totalFetched: 20,
+			pageCount:    2,
+			itemType:     "recipe",
+			hasLimit:     true,
+			expected:     "Showing 10/20 recipes",
+		},
+		{
+			name:         "no limit, multiple pages",
+			itemCount:    10,
+			totalFetched: 20,
+			pageCount:    2,
+			itemType:     "recipe",
+			hasLimit:     false,
+			expected:     "Showing 10 recipes from 2 pages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatShowingSummary(tt.itemCount, tt.totalFetched, tt.pageCount, tt.itemType, tt.hasLimit)
+			if got != tt.expected {
+				t.Errorf("FormatShowingSummary(%d, %d, %d, %q, %t) = %q, want %q",
+					tt.itemCount, tt.totalFetched, tt.pageCount, tt.itemType, tt.hasLimit, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/messages/utils_test.go
+++ b/internal/messages/utils_test.go
@@ -27,14 +27,14 @@ func TestFormatShowingSummary(t *testing.T) {
 		{
 			name:         "no limit, single form",
 			itemCount:    1,
-			totalFetched: 10,
+			totalFetched: 1,
 			itemType:     "resource",
 			expected:     "Showing 1 resource",
 		},
 		{
 			name:         "no limit, plural form",
 			itemCount:    10,
-			totalFetched: 20,
+			totalFetched: 10,
 			itemType:     "recipe",
 			expected:     "Showing 10 recipes",
 		},

--- a/internal/messages/utils_test.go
+++ b/internal/messages/utils_test.go
@@ -2,68 +2,6 @@ package messages
 
 import "testing"
 
-func TestPluralize(t *testing.T) {
-	tests := []struct {
-		name     string
-		word     string
-		count    int
-		expected string
-	}{
-		{
-			name:     "singular cloud returns original word",
-			word:     "cloud",
-			count:    1,
-			expected: "cloud",
-		},
-		{
-			name:     "regular plural adds s",
-			word:     "cloud",
-			count:    2,
-			expected: "clouds",
-		},
-		{
-			name:     "word ending in sh adds es",
-			word:     "flash",
-			count:    3,
-			expected: "flashes",
-		},
-		{
-			name:     "word ending in ch adds es",
-			word:     "torch",
-			count:    0,
-			expected: "torches",
-		},
-		{
-			name:     "word ending in s adds es",
-			word:     "thunderstress",
-			count:    2,
-			expected: "thunderstresses",
-		},
-		{
-			name:     "word ending in x adds es",
-			word:     "vortex",
-			count:    4,
-			expected: "vortexes",
-		},
-		{
-			name:     "word ending in z adds es",
-			word:     "breeze",
-			count:    5,
-			expected: "breezes",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := pluralize(tt.word, tt.count)
-			if got != tt.expected {
-				t.Errorf("Pluralize(%q, %d) = %q, want %q",
-					tt.word, tt.count, got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestFormatShowingSummary(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/messages/utils_test.go
+++ b/internal/messages/utils_test.go
@@ -7,55 +7,50 @@ func TestFormatShowingSummary(t *testing.T) {
 		name         string
 		itemCount    int
 		totalFetched int
-		pageCount    int
 		itemType     string
 		hasLimit     bool
 		expected     string
 	}{
 		{
-			name:         "no limit, single page",
-			itemCount:    10,
-			totalFetched: 10,
-			pageCount:    1,
-			itemType:     "recipe",
-			hasLimit:     false,
-			expected:     "Showing 10 recipes from 1 page",
-		},
-		{
 			name:         "limit, single form",
 			itemCount:    1,
 			totalFetched: 10,
-			pageCount:    1,
 			itemType:     "recipe",
 			hasLimit:     true,
 			expected:     "Showing 1/10 recipe",
 		},
 		{
-			name:         "no limit, multiple pages",
-			itemCount:    10,
-			totalFetched: 20,
-			pageCount:    2,
-			itemType:     "recipe",
-			hasLimit:     false,
-			expected:     "Showing 10 recipes from 2 pages",
-		},
-		{
 			name:         "limit, plural form",
 			itemCount:    10,
 			totalFetched: 20,
-			pageCount:    2,
-			itemType:     "recipe",
+			itemType:     "project",
 			hasLimit:     true,
-			expected:     "Showing 10/20 recipes",
+			expected:     "Showing 10/20 projects",
+		},
+		{
+			name:         "no limit, single form",
+			itemCount:    1,
+			totalFetched: 10,
+			itemType:     "resource",
+			hasLimit:     false,
+			expected:     "Showing 1 resource",
+		},
+		{
+			name:         "no limit, plural form",
+			itemCount:    10,
+			totalFetched: 20,
+			itemType:     "recipe",
+			hasLimit:     false,
+			expected:     "Showing 10 recipes",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatShowingSummary(tt.itemCount, tt.totalFetched, tt.pageCount, tt.itemType, tt.hasLimit)
+			got := FormatShowingSummary(tt.itemCount, tt.totalFetched, tt.itemType, tt.hasLimit)
 			if got != tt.expected {
-				t.Errorf("FormatShowingSummary(%d, %d, %d, %q, %t) = %q, want %q",
-					tt.itemCount, tt.totalFetched, tt.pageCount, tt.itemType, tt.hasLimit, got, tt.expected)
+				t.Errorf("FormatShowingSummary(%d, %d, %q, %t) = %q, want %q",
+					tt.itemCount, tt.totalFetched, tt.itemType, tt.hasLimit, got, tt.expected)
 			}
 		})
 	}

--- a/internal/messages/utils_test.go
+++ b/internal/messages/utils_test.go
@@ -8,7 +8,6 @@ func TestFormatShowingSummary(t *testing.T) {
 		itemCount    int
 		totalFetched int
 		itemType     string
-		hasLimit     bool
 		expected     string
 	}{
 		{
@@ -16,7 +15,6 @@ func TestFormatShowingSummary(t *testing.T) {
 			itemCount:    1,
 			totalFetched: 10,
 			itemType:     "recipe",
-			hasLimit:     true,
 			expected:     "Showing 1/10 recipe",
 		},
 		{
@@ -24,7 +22,6 @@ func TestFormatShowingSummary(t *testing.T) {
 			itemCount:    10,
 			totalFetched: 20,
 			itemType:     "project",
-			hasLimit:     true,
 			expected:     "Showing 10/20 projects",
 		},
 		{
@@ -32,7 +29,6 @@ func TestFormatShowingSummary(t *testing.T) {
 			itemCount:    1,
 			totalFetched: 10,
 			itemType:     "resource",
-			hasLimit:     false,
 			expected:     "Showing 1 resource",
 		},
 		{
@@ -40,17 +36,16 @@ func TestFormatShowingSummary(t *testing.T) {
 			itemCount:    10,
 			totalFetched: 20,
 			itemType:     "recipe",
-			hasLimit:     false,
 			expected:     "Showing 10 recipes",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatShowingSummary(tt.itemCount, tt.totalFetched, tt.itemType, tt.hasLimit)
+			got := FormatShowingSummary(tt.itemCount, tt.totalFetched, tt.itemType)
 			if got != tt.expected {
-				t.Errorf("FormatShowingSummary(%d, %d, %q, %t) = %q, want %q",
-					tt.itemCount, tt.totalFetched, tt.itemType, tt.hasLimit, got, tt.expected)
+				t.Errorf("FormatShowingSummary(%d, %d, %q) = %q, want %q",
+					tt.itemCount, tt.totalFetched, tt.itemType, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
Ensures correct singular/plural usage in CLI count summaries. 

Previously, counts of 1 were incorrectly displayed with plural forms. 

This PR fixes this, removes code duplication and adds some tests.