### PR TITLE
Helpfull error message when not auth token is set

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ func loadTempestToken(cmd *cobra.Command) string {
 
 	t, err := tokenStore.Get()
 	if err != nil {
-		cmd.PrintErrf("Could not get token from the system keyring: %v.\nPlease set TEMPEST_TOKEN_FILE or TEMPEST_TOKEN or run `tempest auth login` first.\n", err)
+		cmd.PrintErrf("Could not get the auth token from the system keyring: %v.\nPlease set either TEMPEST_TOKEN_FILE, TEMPEST_TOKEN or run `tempest auth login` first.\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ func loadTempestToken(cmd *cobra.Command) string {
 
 	t, err := tokenStore.Get()
 	if err != nil {
-		cmd.PrintErrf("get token: %v\n", err)
+		cmd.PrintErrf("Could not get token from the system keyring: %v.\nPlease set TEMPEST_TOKEN_FILE or TEMPEST_TOKEN or run `tempest auth login` first.\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Error message was unclear when auth token was not set.
Before:
```
>~ tempest app serve
get token: exec: "dbus-launch": executable file not found in $PATH
```
After:
```
>~ tempest app serve
Could not get the auth token from the system keyring: exec: "dbus-launch": executable file not found in $PATH.
Please set either TEMPEST_TOKEN_FILE, TEMPEST_TOKEN or run `tempest auth login` first.
```